### PR TITLE
Add support for penpot access token instead of username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,17 +141,22 @@ pip install -e .
 
 ### Configuration
 
-Create a `.env` file based on `env.example` with your Penpot credentials:
+Create a `.env` file based on `env.example` with your Penpot credentials. You can use either:
+- `PENPOT_USERNAME` and `PENPOT_PASSWORD` for email/password authentication, OR
+- `PENPOT_TOKEN` for token-based authentication (which takes precedence if both are provided).
 
 ```
 PENPOT_API_URL=https://design.penpot.app/api
-PENPOT_USERNAME=your_penpot_username
-PENPOT_PASSWORD=your_penpot_password
+PENPOT_USERNAME=your_penpot_username   # Optional: use if you don't have a token
+PENPOT_PASSWORD=your_penpot_password   # Optional: use if you don't have a token
+PENPOT_TOKEN=your_penpot_token         # Optional: token-based authentication (takes precedence)
 PORT=5000
 DEBUG=true
 ```
 
-> **⚠️ CloudFlare Protection Notice**: The Penpot cloud site (penpot.app) uses CloudFlare protection that may occasionally block API requests. If you encounter authentication errors or blocked requests:
+> **Note**: Token authentication is recommended as it avoids CloudFlare verification challenges. You can generate an access token in your Penpot account settings.
+
+> **⚠️ CloudFlare Protection Notice**: If you're using email/password authentication, the Penpot cloud site (penpot.app) uses CloudFlare protection that may occasionally block API requests. If you encounter authentication errors or blocked requests:
 > 1. Open your web browser and navigate to [https://design.penpot.app](https://design.penpot.app)
 > 2. Log in to your Penpot account
 > 3. Complete any CloudFlare human verification challenges if prompted

--- a/env.example
+++ b/env.example
@@ -1,6 +1,7 @@
 # Penpot authentication
 PENPOT_USERNAME=your_penpot_username_here
 PENPOT_PASSWORD=your_penpot_password_here
+PENPOT_TOKEN=your_penpot_token_here
 
 # Server configuration
 PORT=5000

--- a/penpot_mcp/api/penpot_api.py
+++ b/penpot_mcp/api/penpot_api.py
@@ -35,7 +35,8 @@ class PenpotAPI:
             base_url: str = None,
             debug: bool = False,
             email: Optional[str] = None,
-            password: Optional[str] = None):
+            password: Optional[str] = None,
+            token: Optional[str] = None):
         # Load environment variables if not already loaded
         load_dotenv()
 
@@ -47,6 +48,7 @@ class PenpotAPI:
         self.debug = debug
         self.email = email or os.getenv("PENPOT_USERNAME")
         self.password = password or os.getenv("PENPOT_PASSWORD")
+        self.token = token or os.getenv("PENPOT_TOKEN")
         self.profile_id = None
 
         # Set default headers - we'll use different headers at request time
@@ -56,6 +58,10 @@ class PenpotAPI:
             "Content-Type": "application/json",
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
         })
+
+        # If token is provided, set it immediately
+        if self.token:
+            self.set_access_token(self.token)
 
     def _is_cloudflare_error(self, response: requests.Response) -> bool:
         """Check if the response indicates a CloudFlare error."""
@@ -147,6 +153,12 @@ class PenpotAPI:
         Returns:
             Auth token for API calls
         """
+        # If token is already set, no need to login
+        if self.token:
+            if self.debug:
+                print("\nUsing existing token for authentication")
+            return self.token
+            
         # Use the export authentication which also extracts profile ID
         token = self.login_for_export(email, password)
         self.set_access_token(token)


### PR DESCRIPTION
## Description

Added support for Penpot Acces Token which can be uesd to auth requests directly instead of using username and password to create an access token. This access token is set with the env var `PENPOT_TOKEN` and when set, it will be used instead of PENPOT_USERNAME and PENPOT_PASSWORD.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Fixes #(issue number)

## Changes Made

- [ ] Added/modified MCP tools or resources
- [x] Updated Penpot API integration
- [ ] Enhanced AI assistant compatibility
- [ ] Improved error handling
- [ ] Added tests
- [ ] Updated documentation

## Testing

- [x] Tests pass locally
- [ ] Added tests for new functionality
- [ ] Tested with Claude Desktop integration
- [x] Tested with Penpot API
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know. 