### PR TITLE
test: Add actual MCP tool implementation tests

### DIFF
--- a/.github/TESTING_CI.md
+++ b/.github/TESTING_CI.md
@@ -1,0 +1,1 @@
+# Testing CI

--- a/.github/TESTING_CI.md
+++ b/.github/TESTING_CI.md
@@ -1,1 +1,2 @@
 # Testing CI
+Testing CI workflow trigger - Wed, Oct  8, 2025  8:55:51 PM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ main, develop ]
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,17 +105,24 @@ penpot-validate path/to/penpot_file.json
 - `delete_object`: Delete an object from a page
 - `apply_design_changes`: Apply multiple changes atomically
 
-**Advanced Shape Helpers (Phase 3):**
+**Advanced Shape Tools (Phase 3):**
 - `create_path`: Create custom vector paths with points
+- `create_group`: Create group containers for organizing objects
+- `add_object_to_group`: Add existing objects to a group
 - `create_boolean_shape`: Boolean operations (union, difference, intersection, exclusion)
-- `create_parent_operation`: Set object parent for grouping
-- `create_group`: Create group containers (already implemented in Phase 2)
 
-**Advanced Styling Helpers (Phase 3):**
-- `create_gradient_fill`: Create linear or radial gradient fills
+**Advanced Styling Tools (Phase 3):**
+- `apply_gradient`: Apply linear or radial gradient fills with angle control
+- `add_stroke`: Add strokes/borders with style options (solid, dashed, dotted)
+- `add_shadow`: Add drop shadow effects with spread
+- `apply_blur`: Apply layer or background blur effects
+
+**Advanced Shape/Styling Helpers (API level):**
+- `create_gradient_fill`: Create linear or radial gradient fill definitions
 - `create_stroke`: Create stroke/border definitions with style, cap, and join options
-- `create_shadow`: Create drop shadow effects
-- `create_blur`: Create layer or background blur effects
+- `create_shadow`: Create drop shadow effect definitions
+- `create_blur`: Create layer or background blur effect definitions
+- `create_parent_operation`: Set object parent for grouping
 - `create_fill_operation`: Create operation to set fill(s) on an object
 - `create_stroke_operation`: Create operation to set stroke(s) on an object
 - `create_shadow_operation`: Create operation to set shadow(s) on an object
@@ -304,7 +311,267 @@ export_object(
 )
 ```
 
-### Advanced Shape Creation Workflow (Phase 3)
+### Phase 3: Advanced Design with MCP Tools
+
+The following examples show how to use the Phase 3 MCP tools for advanced design features. These are high-level tools that handle session management automatically.
+
+#### 1. Creating Custom Paths
+
+```python
+# Create a triangle using the create_path MCP tool
+create_path(
+    file_id="file-123",
+    page_id="page-456",
+    points=[
+        {"x": 50, "y": 0},
+        {"x": 100, "y": 100},
+        {"x": 0, "y": 100}
+    ],
+    closed=True,
+    fill_color="#ff0000",
+    stroke_color="#000000",
+    stroke_width=2,
+    name="Triangle"
+)
+
+# Create a star shape
+create_path(
+    file_id="file-123",
+    page_id="page-456",
+    points=[
+        {"x": 50, "y": 0},
+        {"x": 61, "y": 35},
+        {"x": 98, "y": 35},
+        {"x": 68, "y": 57},
+        {"x": 79, "y": 91},
+        {"x": 50, "y": 70},
+        {"x": 21, "y": 91},
+        {"x": 32, "y": 57},
+        {"x": 2, "y": 35},
+        {"x": 39, "y": 35}
+    ],
+    closed=True,
+    fill_color="#FFD700",
+    name="Star"
+)
+```
+
+#### 2. Grouping Objects
+
+```python
+# Create a group
+group_result = create_group(
+    file_id="file-123",
+    page_id="page-456",
+    name="Button Components"
+)
+group_id = group_result['groupId']
+
+# Add objects to the group
+add_object_to_group(
+    file_id="file-123",
+    object_id="rect-id",
+    group_id=group_id
+)
+
+add_object_to_group(
+    file_id="file-123",
+    object_id="text-id",
+    group_id=group_id
+)
+```
+
+#### 3. Boolean Operations
+
+```python
+# Create two overlapping circles first
+circle1 = add_circle(
+    file_id="file-123",
+    page_id="page-456",
+    cx=50, cy=50, radius=40,
+    fill_color="#ff0000"
+)
+
+circle2 = add_circle(
+    file_id="file-123",
+    page_id="page-456",
+    cx=80, cy=50, radius=40,
+    fill_color="#0000ff"
+)
+
+# Create union of the circles
+create_boolean_shape(
+    file_id="file-123",
+    page_id="page-456",
+    operation="union",
+    shape_ids=[circle1['objectId'], circle2['objectId']],
+    name="Merged Circles"
+)
+
+# Or create a difference (subtract second from first)
+create_boolean_shape(
+    file_id="file-123",
+    page_id="page-456",
+    operation="difference",
+    shape_ids=[circle1['objectId'], circle2['objectId']],
+    name="Donut Shape"
+)
+```
+
+#### 4. Applying Gradients
+
+```python
+# Apply a linear gradient at 45 degrees
+apply_gradient(
+    file_id="file-123",
+    object_id="rect-id",
+    gradient_type="linear",
+    start_color="#ff0000",
+    end_color="#0000ff",
+    angle=45
+)
+
+# Apply a radial gradient (angle is ignored for radial)
+apply_gradient(
+    file_id="file-123",
+    object_id="circle-id",
+    gradient_type="radial",
+    start_color="#ffffff",
+    end_color="#000000",
+    angle=0
+)
+```
+
+#### 5. Adding Strokes and Shadows
+
+```python
+# Add a dashed stroke
+add_stroke(
+    file_id="file-123",
+    object_id="rect-id",
+    color="#000000",
+    width=3.0,
+    style="dashed"
+)
+
+# Add a drop shadow
+add_shadow(
+    file_id="file-123",
+    object_id="rect-id",
+    color="#00000080",  # 50% transparent black
+    offset_x=4,
+    offset_y=4,
+    blur=8,
+    spread=2
+)
+```
+
+#### 6. Applying Blur Effects
+
+```python
+# Apply layer blur
+apply_blur(
+    file_id="file-123",
+    object_id="rect-id",
+    blur_amount=10,
+    blur_type="layer-blur"
+)
+
+# Apply background blur
+apply_blur(
+    file_id="file-123",
+    object_id="rect-id",
+    blur_amount=15,
+    blur_type="background-blur"
+)
+```
+
+#### 7. Creating a Complete Design
+
+```python
+# Create a modern card design with advanced features
+# 1. Create card background with gradient
+card = add_rectangle(
+    file_id="file-123",
+    page_id="page-456",
+    x=50, y=50,
+    width=300, height=200,
+    name="Card Background"
+)
+
+apply_gradient(
+    file_id="file-123",
+    object_id=card['objectId'],
+    gradient_type="linear",
+    start_color="#667eea",
+    end_color="#764ba2",
+    angle=135
+)
+
+# 2. Add shadow to card
+add_shadow(
+    file_id="file-123",
+    object_id=card['objectId'],
+    color="#00000040",
+    offset_x=0,
+    offset_y=8,
+    blur=16,
+    spread=0
+)
+
+# 3. Create icon using custom path
+icon = create_path(
+    file_id="file-123",
+    page_id="page-456",
+    points=[
+        {"x": 100, "y": 80},
+        {"x": 120, "y": 100},
+        {"x": 100, "y": 120},
+        {"x": 80, "y": 100}
+    ],
+    closed=True,
+    fill_color="#ffffff",
+    name="Icon"
+)
+
+# 4. Add text with shadow
+text = add_text(
+    file_id="file-123",
+    page_id="page-456",
+    x=150, y=100,
+    content="Premium",
+    font_size=24,
+    fill_color="#ffffff",
+    name="Title"
+)
+
+add_shadow(
+    file_id="file-123",
+    object_id=text['objectId'],
+    color="#00000060",
+    offset_x=0,
+    offset_y=2,
+    blur=4
+)
+
+# 5. Group all elements
+group = create_group(
+    file_id="file-123",
+    page_id="page-456",
+    name="Card Component"
+)
+
+for obj_id in [card['objectId'], icon['objectId'], text['objectId']]:
+    add_object_to_group(
+        file_id="file-123",
+        object_id=obj_id,
+        group_id=group['groupId']
+    )
+```
+
+### Advanced Shape Creation Workflow (Phase 3 - API Level)
+
+The following examples show the lower-level API methods for advanced control. These require manual session management.
 
 #### 1. Creating Custom Vector Paths
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,16 @@ penpot-validate path/to/penpot_file.json
 - `create_parent_operation`: Set object parent for grouping
 - `create_group`: Create group containers (already implemented in Phase 2)
 
+**Advanced Styling Helpers (Phase 3):**
+- `create_gradient_fill`: Create linear or radial gradient fills
+- `create_stroke`: Create stroke/border definitions with style, cap, and join options
+- `create_shadow`: Create drop shadow effects
+- `create_blur`: Create layer or background blur effects
+- `create_fill_operation`: Create operation to set fill(s) on an object
+- `create_stroke_operation`: Create operation to set stroke(s) on an object
+- `create_shadow_operation`: Create operation to set shadow(s) on an object
+- `create_blur_operation`: Create operation to set blur effect on an object
+
 ### Environment Configuration
 
 Create a `.env` file with:
@@ -486,6 +496,221 @@ changes = [
 
 with api.editing_session("file-id") as (session_id, revn):
     api.update_file("file-id", session_id, revn, changes)
+```
+
+### Advanced Styling Workflow (Phase 3)
+
+#### 1. Applying Gradients to Shapes
+
+```python
+# Create a rectangle with a linear gradient
+api = PenpotAPI()
+
+# Create rectangle
+rect = api.create_rectangle(x=100, y=100, width=200, height=100)
+rect_id = api.generate_session_id()
+
+# Create linear gradient (left to right)
+gradient = api.create_gradient_fill(
+    gradient_type='linear',
+    start_color='#ff0000',
+    end_color='#0000ff',
+    start_x=0.0,
+    start_y=0.0,
+    end_x=1.0,
+    end_y=0.0
+)
+
+# Apply gradient to rectangle
+rect['fills'] = [gradient]
+
+# Add to file
+change = api.create_add_obj_change(rect_id, "page-id", rect)
+
+with api.editing_session("file-id") as (session_id, revn):
+    api.update_file("file-id", session_id, revn, [change])
+```
+
+#### 2. Applying Multiple Strokes
+
+```python
+# Add multiple strokes to create outline effects
+api = PenpotAPI()
+
+# Create circle
+circle = api.create_circle(cx=150, cy=150, radius=50)
+circle_id = api.generate_session_id()
+
+# Create outer thick stroke
+outer_stroke = api.create_stroke(
+    color='#000000',
+    width=5.0,
+    style='solid',
+    cap='round',
+    join='round'
+)
+
+# Create inner dashed stroke
+inner_stroke = api.create_stroke(
+    color='#ff0000',
+    width=2.0,
+    style='dashed',
+    cap='round',
+    join='round'
+)
+
+# Apply both strokes
+stroke_op = api.create_stroke_operation([outer_stroke, inner_stroke])
+
+# Create change
+change = api.create_mod_obj_change(circle_id, [stroke_op])
+
+with api.editing_session("file-id") as (session_id, revn):
+    api.update_file("file-id", session_id, revn, [change])
+```
+
+#### 3. Adding Shadow Effects
+
+```python
+# Add drop shadow to text
+api = PenpotAPI()
+
+# Create text
+text = api.create_text(x=50, y=50, content="Hello World", font_size=48)
+text_id = api.generate_session_id()
+
+# Create drop shadow with semi-transparent color
+shadow = api.create_shadow(
+    color='#00000080',  # 50% transparent black
+    offset_x=2,
+    offset_y=2,
+    blur=4,
+    spread=1.0
+)
+
+# Apply shadow
+shadow_op = api.create_shadow_operation([shadow])
+
+# Create change
+change = api.create_mod_obj_change(text_id, [shadow_op])
+
+with api.editing_session("file-id") as (session_id, revn):
+    api.update_file("file-id", session_id, revn, [change])
+```
+
+#### 4. Applying Blur Effects
+
+```python
+# Add layer blur to create depth effect
+api = PenpotAPI()
+
+rect_id = "existing-rect-id"
+
+# Create layer blur
+blur = api.create_blur(
+    blur_type='layer-blur',
+    value=10
+)
+
+# Apply blur
+blur_op = api.create_blur_operation(blur)
+
+# Create change
+change = api.create_mod_obj_change(rect_id, [blur_op])
+
+with api.editing_session("file-id") as (session_id, revn):
+    api.update_file("file-id", session_id, revn, [change])
+```
+
+#### 5. Combining Multiple Style Effects
+
+```python
+# Apply gradient, stroke, shadow, and blur together
+api = PenpotAPI()
+
+# Create rectangle
+rect = api.create_rectangle(x=100, y=100, width=200, height=100)
+rect_id = api.generate_session_id()
+
+# Add rectangle to file first
+add_change = api.create_add_obj_change(rect_id, "page-id", rect)
+
+with api.editing_session("file-id") as (session_id, revn):
+    api.update_file("file-id", session_id, revn, [add_change])
+
+# Now apply all styling effects
+# Create radial gradient
+gradient = api.create_gradient_fill(
+    gradient_type='radial',
+    start_color='#ff00ff',
+    end_color='#00ffff',
+    start_x=0.5,
+    start_y=0.5,
+    end_x=1.0,
+    end_y=1.0
+)
+fill_op = api.create_fill_operation([gradient])
+
+# Create stroke
+stroke = api.create_stroke(
+    color='#000000',
+    width=3.0,
+    style='solid'
+)
+stroke_op = api.create_stroke_operation([stroke])
+
+# Create shadow
+shadow = api.create_shadow(
+    color='#00000080',
+    offset_x=5,
+    offset_y=5,
+    blur=10
+)
+shadow_op = api.create_shadow_operation([shadow])
+
+# Create blur
+blur = api.create_blur('layer-blur', 5)
+blur_op = api.create_blur_operation(blur)
+
+# Apply all effects
+style_change = api.create_mod_obj_change(rect_id, [
+    fill_op,
+    stroke_op,
+    shadow_op,
+    blur_op
+])
+
+with api.editing_session("file-id") as (session_id, revn):
+    api.update_file("file-id", session_id, revn, [style_change])
+```
+
+#### 6. Creating Shape with Gradient from Start
+
+```python
+# Create shape with gradient in one step
+api = PenpotAPI()
+
+# Create gradient
+gradient = api.create_gradient_fill(
+    gradient_type='linear',
+    start_color='#ff0000',
+    end_color='#ffff00',
+    start_x=0.0,
+    start_y=0.0,
+    end_x=1.0,
+    end_y=1.0  # Diagonal gradient
+)
+
+# Create circle with gradient
+circle = api.create_circle(cx=150, cy=150, radius=50)
+circle['fills'] = [gradient]  # Replace default fill with gradient
+
+# Add to file
+circle_id = api.generate_session_id()
+change = api.create_add_obj_change(circle_id, "page-id", circle)
+
+with api.editing_session("file-id") as (session_id, revn):
+    api.update_file("file-id", session_id, revn, [change])
 ```
 
 ### Testing Patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -980,6 +980,98 @@ with api.editing_session("file-id") as (session_id, revn):
     api.update_file("file-id", session_id, revn, [change])
 ```
 
+### Comments & Collaboration Workflow
+
+The Penpot MCP server supports adding comments to designs for collaboration and review.
+
+#### Creating Comment Threads
+
+```python
+# Add a comment to a design
+result = add_design_comment(
+    file_id="file-123",
+    page_id="page-456",
+    x=150,  # X position on the canvas
+    y=200,  # Y position on the canvas
+    comment="This button needs to be larger"
+)
+
+thread_id = result['thread_id']
+```
+
+#### Replying to Comments
+
+```python
+# Add a reply to an existing thread
+reply = reply_to_comment(
+    thread_id=thread_id,
+    reply="Agreed! I'll increase the size by 20%"
+)
+```
+
+#### Retrieving Comments
+
+```python
+# Get all comment threads for a file
+all_comments = get_file_comments(file_id="file-123")
+
+# Get comments for a specific page
+page_comments = get_file_comments(
+    file_id="file-123",
+    page_id="page-456"
+)
+
+print(f"Found {page_comments['count']} comment threads")
+for thread in page_comments['threads']:
+    print(f"Comment at ({thread['position']['x']}, {thread['position']['y']})")
+```
+
+#### Resolving Comments
+
+```python
+# Mark a comment thread as resolved
+result = resolve_comment_thread(thread_id=thread_id)
+```
+
+#### AI-Assisted Design Review Example
+
+```python
+# 1. Get the design file
+file_data = get_file(file_id="design-123")
+
+# 2. Analyze the design and add review comments
+comments = [
+    {
+        'x': 100, 'y': 150,
+        'comment': 'Consider using higher contrast for accessibility'
+    },
+    {
+        'x': 300, 'y': 200,
+        'comment': 'This heading should use the brand font (Roboto Bold)'
+    },
+    {
+        'x': 450, 'y': 300,
+        'comment': 'Button padding seems inconsistent with design system'
+    }
+]
+
+# 3. Add all comments to the design
+for c in comments:
+    add_design_comment(
+        file_id="design-123",
+        page_id="page-1",
+        x=c['x'],
+        y=c['y'],
+        comment=c['comment']
+    )
+
+# 4. Review and resolve comments as fixes are made
+all_threads = get_file_comments(file_id="design-123")
+for thread in all_threads['threads']:
+    # After verifying the fix, resolve the thread
+    resolve_comment_thread(thread_id=thread['id'])
+```
+
 ### Testing Patterns
 
 - Mock fixtures in `tests/conftest.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,10 @@ penpot-validate path/to/penpot_file.json
    - **Caching**: In-memory file cache to reduce API calls
    - **Resource/Tool Duality**: Resources can be exposed as tools via RESOURCES_AS_TOOLS config
    - **Transit Format**: Special handling for UUIDs (`~u` prefix) and keywords (`~:` prefix)
+   - **Session and Revision Management**: Every file update requires a session ID and revision number
+     - Session ID: Generated UUID for tracking edit sessions
+     - Revision number: Integer that increments with each change
+     - Use `editing_session()` context manager for convenience
 
 ### Available Tools/Functions
 
@@ -101,6 +105,14 @@ DEBUG=true               # debug logging
 3. **Error Handling**: Always check for `"error"` keys in API responses
 4. **Testing**: Use `test_mode=True` when creating server instances in tests
 5. **Transit Format**: Remember to handle Transit+JSON when working with raw API
+6. **Session Management**: Use `editing_session()` context manager for file updates
+   - Automatically generates session ID and retrieves current revision
+   - Example:
+     ```python
+     with api.editing_session("file-id") as (session_id, revn):
+         # Use session_id and revn for update operations
+         api.update_file(file_id, session_id, revn, changes)
+     ```
 
 ### Common Workflow for Code Generation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,13 +77,25 @@ penpot-validate path/to/penpot_file.json
 
 ### Available Tools/Functions
 
+**File Management:**
 - `list_projects`: Get all Penpot projects
 - `get_project_files`: List files in a project
 - `get_file`: Retrieve and cache file data
+- `create_file`: Create new Penpot design file
+- `delete_file`: Delete a Penpot file
+- `rename_file`: Rename a Penpot file
+
+**Design Exploration:**
 - `search_object`: Search design objects by name (regex)
 - `get_object_tree`: Get filtered object tree with screenshot
 - `export_object`: Export design objects as images
 - `penpot_tree_schema`: Get schema for object tree fields
+
+**Shape Creation (Phase 2):**
+- `add_rectangle`: Add a rectangle to the design
+- `add_circle`: Add a circle to the design
+- `add_text`: Add text to the design
+- `add_frame`: Create a new frame (artboard) in the design
 
 ### Environment Configuration
 
@@ -122,6 +134,70 @@ DEBUG=true               # debug logging
 4. Get tree schema → Understand available fields
 5. Get object tree → Retrieve structure with screenshot
 6. Export if needed → Get rendered component image
+
+### Common Workflow for Creating Designs
+
+1. Create or locate file → Use `create_file` or `get_file`
+2. Get page ID → From file data (e.g., file['data']['pages'][0]['id'])
+3. Create shapes → Use `add_rectangle`, `add_circle`, `add_text`, or `add_frame`
+4. Nest in frames → Use `frame_id` parameter to add shapes inside frames
+
+**Example: Creating a Simple UI Layout**
+
+```python
+# 1. Create a new file
+file = create_file(name="Mobile UI", project_id="project-123")
+file_id = file['id']
+page_id = file['data']['pages'][0]['id']
+
+# 2. Create a frame (artboard) for mobile screen
+frame_result = add_frame(
+    file_id=file_id,
+    page_id=page_id,
+    x=0, y=0,
+    width=375, height=812,
+    name="iPhone 13",
+    background_color="#FFFFFF"
+)
+frame_id = frame_result['frameId']
+
+# 3. Add a header rectangle inside the frame
+header = add_rectangle(
+    file_id=file_id,
+    page_id=page_id,
+    x=0, y=0,
+    width=375, height=60,
+    name="Header",
+    fill_color="#4A90E2",
+    frame_id=frame_id
+)
+
+# 4. Add title text inside the frame
+title = add_text(
+    file_id=file_id,
+    page_id=page_id,
+    x=20, y=20,
+    content="My App",
+    name="Title",
+    font_size=24,
+    fill_color="#FFFFFF",
+    font_family="Work Sans",
+    frame_id=frame_id
+)
+
+# 5. Add a circular avatar
+avatar = add_circle(
+    file_id=file_id,
+    page_id=page_id,
+    cx=187, cy=150,
+    radius=40,
+    name="Avatar",
+    fill_color="#E0E0E0",
+    stroke_color="#CCCCCC",
+    stroke_width=2,
+    frame_id=frame_id
+)
+```
 
 ### Testing Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ penpot-validate path/to/penpot_file.json
 
 ### Available Tools/Functions
 
+#### Query and Navigation Tools
 - `list_projects`: Get all Penpot projects
 - `get_project_files`: List files in a project
 - `get_file`: Retrieve and cache file data
@@ -84,6 +85,14 @@ penpot-validate path/to/penpot_file.json
 - `get_object_tree`: Get filtered object tree with screenshot
 - `export_object`: Export design objects as images
 - `penpot_tree_schema`: Get schema for object tree fields
+
+#### Object Modification Tools
+- `move_object`: Move an object to new coordinates (x, y)
+- `resize_object`: Resize an object (width, height)
+- `change_object_color`: Change fill color and opacity
+- `rotate_object`: Rotate an object by degrees
+- `delete_object`: Delete an object from a page
+- `apply_design_changes`: Apply multiple changes atomically
 
 ### Environment Configuration
 
@@ -122,6 +131,121 @@ DEBUG=true               # debug logging
 4. Get tree schema → Understand available fields
 5. Get object tree → Retrieve structure with screenshot
 6. Export if needed → Get rendered component image
+
+### Complete Design Workflow Example
+
+#### 1. Create File and Project
+```python
+# Create a new project
+create_project(team_id="team-123", name="My Design Project")
+
+# Create a new file
+create_file(name="My Design", project_id="project-123")
+```
+
+#### 2. Add Shapes
+```python
+# Add a rectangle
+from penpot_mcp.api import PenpotAPI
+
+api = PenpotAPI()
+
+# Create a rectangle shape
+rect = api.create_rectangle(
+    x=100, y=100, 
+    width=200, height=150,
+    fill_color="#FF0000"
+)
+
+# Generate ID and create change
+rect_id = api.generate_session_id()
+change = api.create_add_obj_change(rect_id, "page-id", rect)
+
+# Apply change using editing session
+with api.editing_session("file-id") as (session_id, revn):
+    api.update_file("file-id", session_id, revn, [change])
+```
+
+#### 3. Modify Shapes
+```python
+# Move the rectangle
+move_object(
+    file_id="file-123", 
+    object_id="rect-id", 
+    x=200, 
+    y=150
+)
+
+# Resize it
+resize_object(
+    file_id="file-123",
+    object_id="rect-id",
+    width=300,
+    height=200
+)
+
+# Change color
+change_object_color(
+    file_id="file-123",
+    object_id="rect-id",
+    fill_color="#00FF00",
+    fill_opacity=0.8
+)
+
+# Rotate it
+rotate_object(
+    file_id="file-123",
+    object_id="rect-id",
+    rotation=45
+)
+```
+
+#### 4. Batch Operations
+```python
+# Apply multiple changes atomically
+changes = [
+    {
+        "type": "mod-obj",
+        "id": "rect-1",
+        "operations": [
+            {"type": "set", "attr": "x", "val": 100},
+            {"type": "set", "attr": "y", "val": 100}
+        ]
+    },
+    {
+        "type": "mod-obj",
+        "id": "rect-2",
+        "operations": [
+            {"type": "set", "attr": "x", "val": 200},
+            {"type": "set", "attr": "y", "val": 200}
+        ]
+    }
+]
+
+apply_design_changes(file_id="file-123", changes=changes)
+```
+
+#### 5. Delete Shapes
+```python
+# Delete an object
+delete_object(
+    file_id="file-123",
+    page_id="page-456",
+    object_id="rect-id"
+)
+```
+
+#### 6. Export Result
+```python
+# Export the final design
+export_object(
+    file_id="file-123",
+    page_id="page-456",
+    object_id="frame-id",
+    export_type="png",
+    scale=2
+)
+```
 
 ### Testing Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,8 @@ penpot-validate path/to/penpot_file.json
 - `import_component`: Import a component from a library into the design
 - `sync_library`: Synchronize component instances with their library
 - `publish_as_library`: Publish a file as a shared component library
+- `unpublish_library`: Unpublish a file as a library
+- `get_file_libraries`: Get all libraries linked to a file
 
 **Library & Component System Helpers (API level):**
 - `get_file_libraries`: Get all libraries linked to a file
@@ -1129,20 +1131,24 @@ print(f"Library published: {publish_result['file']['name']}")
 #### Linking a Library and Using Components
 
 ```python
-# 1. Link the library to your design file
+# 1. Check what libraries are already linked (optional)
+linked_libs = get_file_libraries(file_id="design-file-123")
+print(f"Currently linked to {linked_libs['count']} libraries")
+
+# 2. Link the library to your design file
 link_result = link_library(
     file_id="design-file-123",
     library_id="library-file-456"
 )
 print("Library linked successfully")
 
-# 2. List available components from the library
+# 3. List available components from the library
 components_result = list_library_components(library_id="library-file-456")
 print(f"Found {components_result['count']} components:")
 for component in components_result['components']:
     print(f"  - {component['name']} (ID: {component['id']})")
 
-# 3. Import components into your design
+# 4. Import components into your design
 button_instance = import_component(
     file_id="design-file-123",
     page_id="page-1",
@@ -1162,6 +1168,14 @@ card_instance = import_component(
 )
 
 print("Components imported successfully")
+```
+
+#### Unpublishing a Library
+
+```python
+# Remove library status from a file
+unpublish_result = unpublish_library(file_id="library-file-456")
+print(f"Library unpublished: {unpublish_result['file']['name']}")
 ```
 
 #### Synchronizing Component Instances

--- a/penpot_mcp/api/__init__.py
+++ b/penpot_mcp/api/__init__.py
@@ -1,1 +1,6 @@
 """PenpotAPI module for interacting with the Penpot design platform."""
+
+from .penpot_api import PenpotAPI, PenpotAPIError, RevisionConflictError, CloudFlareError
+
+__all__ = ['PenpotAPI', 'PenpotAPIError', 'RevisionConflictError', 'CloudFlareError']
+

--- a/penpot_mcp/api/__init__.py
+++ b/penpot_mcp/api/__init__.py
@@ -1,6 +1,11 @@
 """PenpotAPI module for interacting with the Penpot design platform."""
 
-from .penpot_api import PenpotAPI, PenpotAPIError, RevisionConflictError, CloudFlareError
+from .penpot_api import (
+    CloudFlareError,
+    PenpotAPI,
+    PenpotAPIError,
+    RevisionConflictError,
+)
 
 __all__ = ['PenpotAPI', 'PenpotAPIError', 'RevisionConflictError', 'CloudFlareError']
 

--- a/penpot_mcp/api/penpot_api.py
+++ b/penpot_mcp/api/penpot_api.py
@@ -581,6 +581,155 @@ class PenpotAPI:
 
         return data
 
+    def create_file(
+        self,
+        name: str,
+        project_id: str,
+        is_shared: bool = False,
+        features: Optional[List[str]] = None,
+        file_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Create a new Penpot file.
+
+        Args:
+            name: File name
+            project_id: UUID of the project to create file in
+            is_shared: Whether the file is shared
+            features: Optional list of feature flags
+            file_id: Optional custom file UUID (auto-generated if not provided)
+
+        Returns:
+            Dictionary containing created file information including:
+            - id: File UUID
+            - name: File name
+            - projectId: Project UUID
+            - created: Creation timestamp
+            - modified: Last modified timestamp
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> result = api.create_file(name="My Design", project_id="abc-123")
+            >>> print(result['id'])
+        """
+        url = f"{self.base_url}/rpc/command/create-file"
+
+        payload = {
+            "name": name,
+            "project-id": project_id,
+            "is-shared": is_shared
+        }
+
+        if file_id:
+            payload["id"] = file_id
+        if features:
+            payload["features"] = features
+
+        response = self._make_authenticated_request('post', url, json=payload, use_transit=False)
+        data = response.json()
+
+        if self.debug:
+            print(f"\nFile created: {data.get('name')} (ID: {data.get('id')})")
+
+        return data
+
+    def delete_file(self, file_id: str) -> Dict[str, Any]:
+        """
+        Delete a Penpot file.
+
+        Args:
+            file_id: UUID of the file to delete
+
+        Returns:
+            Success confirmation or error details
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> result = api.delete_file(file_id="abc-123")
+        """
+        url = f"{self.base_url}/rpc/command/delete-file"
+
+        payload = {
+            "id": file_id
+        }
+
+        response = self._make_authenticated_request('post', url, json=payload, use_transit=False)
+        
+        # Some DELETE operations might return empty responses or just status codes
+        try:
+            data = response.json()
+        except Exception:
+            # If no JSON response, return success based on status code
+            data = {"success": True, "id": file_id}
+
+        if self.debug:
+            print(f"\nFile deleted: {file_id}")
+
+        return data
+
+    def rename_file(self, file_id: str, name: str) -> Dict[str, Any]:
+        """
+        Rename a Penpot file.
+
+        Args:
+            file_id: UUID of the file to rename
+            name: New file name
+
+        Returns:
+            Updated file information
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> result = api.rename_file(file_id="abc-123", name="New Name")
+            >>> print(result['name'])
+        """
+        url = f"{self.base_url}/rpc/command/rename-file"
+
+        payload = {
+            "id": file_id,
+            "name": name
+        }
+
+        response = self._make_authenticated_request('post', url, json=payload, use_transit=False)
+        data = response.json()
+
+        if self.debug:
+            print(f"\nFile renamed to: {name} (ID: {file_id})")
+
+        return data
+
+    def set_file_shared(self, file_id: str, is_shared: bool) -> Dict[str, Any]:
+        """
+        Set file sharing status.
+
+        Args:
+            file_id: UUID of the file
+            is_shared: Whether the file should be shared
+
+        Returns:
+            Updated file information
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> result = api.set_file_shared(file_id="abc-123", is_shared=True)
+            >>> print(result['isShared'])
+        """
+        url = f"{self.base_url}/rpc/command/set-file-shared"
+
+        payload = {
+            "id": file_id,
+            "is-shared": is_shared
+        }
+
+        response = self._make_authenticated_request('post', url, json=payload, use_transit=False)
+        data = response.json()
+
+        if self.debug:
+            shared_status = "shared" if is_shared else "not shared"
+            print(f"\nFile set to {shared_status}: {file_id}")
+
+        return data
+
     def create_export(self, file_id: str, page_id: str, object_id: str,
                       export_type: str = "png", scale: int = 1,
                       email: Optional[str] = None, password: Optional[str] = None,

--- a/penpot_mcp/api/penpot_api.py
+++ b/penpot_mcp/api/penpot_api.py
@@ -1451,6 +1451,256 @@ class PenpotAPI:
         """
         return self.create_set_operation('parentId', parent_id)
 
+    def create_gradient_fill(
+        self,
+        gradient_type: str,
+        start_color: str,
+        end_color: str,
+        start_x: float = 0.0,
+        start_y: float = 0.0,
+        end_x: float = 1.0,
+        end_y: float = 1.0,
+        **kwargs
+    ) -> dict:
+        """
+        Create a gradient fill definition.
+
+        Args:
+            gradient_type: Type of gradient ('linear' or 'radial')
+            start_color: Start color in hex format (e.g., '#ff0000')
+            end_color: End color in hex format
+            start_x: Start X position (0.0-1.0, relative to shape)
+            start_y: Start Y position (0.0-1.0, relative to shape)
+            end_x: End X position (0.0-1.0, relative to shape)
+            end_y: End Y position (0.0-1.0, relative to shape)
+            **kwargs: Additional gradient properties
+
+        Returns:
+            Gradient fill dictionary
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> # Linear gradient from red to blue
+            >>> gradient = api.create_gradient_fill(
+            ...     'linear',
+            ...     '#ff0000',
+            ...     '#0000ff',
+            ...     start_x=0, start_y=0,
+            ...     end_x=1, end_y=0
+            ... )
+        """
+        valid_types = ['linear', 'radial']
+        if gradient_type not in valid_types:
+            raise ValueError(f"Invalid gradient_type '{gradient_type}'. Must be one of: {', '.join(valid_types)}")
+
+        gradient = {
+            'type': f'{gradient_type}-gradient',
+            'start-color': start_color,
+            'end-color': end_color,
+            'start-x': start_x,
+            'start-y': start_y,
+            'end-x': end_x,
+            'end-y': end_y
+        }
+
+        gradient.update(kwargs)
+
+        return gradient
+
+    def create_stroke(
+        self,
+        color: str,
+        width: float = 1.0,
+        style: str = 'solid',
+        cap: str = 'round',
+        join: str = 'round',
+        **kwargs
+    ) -> dict:
+        """
+        Create a stroke (border) definition.
+
+        Args:
+            color: Stroke color in hex format
+            width: Stroke width in pixels (default: 1.0)
+            style: Stroke style ('solid', 'dashed', 'dotted', 'mixed')
+            cap: Line cap style ('round', 'square', 'butt')
+            join: Line join style ('round', 'bevel', 'miter')
+            **kwargs: Additional stroke properties
+
+        Returns:
+            Stroke dictionary
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> stroke = api.create_stroke('#000000', width=2.0, style='dashed')
+        """
+        valid_styles = ['solid', 'dashed', 'dotted', 'mixed']
+        if style not in valid_styles:
+            raise ValueError(f"Invalid style '{style}'. Must be one of: {', '.join(valid_styles)}")
+
+        valid_caps = ['round', 'square', 'butt']
+        if cap not in valid_caps:
+            raise ValueError(f"Invalid cap '{cap}'. Must be one of: {', '.join(valid_caps)}")
+
+        valid_joins = ['round', 'bevel', 'miter']
+        if join not in valid_joins:
+            raise ValueError(f"Invalid join '{join}'. Must be one of: {', '.join(valid_joins)}")
+
+        stroke = {
+            'stroke-color': color,
+            'stroke-width': width,
+            'stroke-style': style,
+            'stroke-cap': cap,
+            'stroke-join': join
+        }
+
+        stroke.update(kwargs)
+
+        return stroke
+
+    def create_shadow(
+        self,
+        color: str,
+        offset_x: float,
+        offset_y: float,
+        blur: float,
+        spread: float = 0.0,
+        hidden: bool = False,
+        **kwargs
+    ) -> dict:
+        """
+        Create a drop shadow effect.
+
+        Args:
+            color: Shadow color in hex format with alpha (e.g., '#00000080')
+            offset_x: Horizontal offset in pixels
+            offset_y: Vertical offset in pixels
+            blur: Blur radius in pixels
+            spread: Spread radius in pixels (default: 0.0)
+            hidden: Whether shadow is hidden (default: False)
+            **kwargs: Additional shadow properties
+
+        Returns:
+            Shadow dictionary
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> shadow = api.create_shadow('#00000080', 2, 2, 4)
+        """
+        shadow = {
+            'color': color,
+            'offset-x': offset_x,
+            'offset-y': offset_y,
+            'blur': blur,
+            'spread': spread,
+            'hidden': hidden
+        }
+
+        shadow.update(kwargs)
+
+        return shadow
+
+    def create_blur(
+        self,
+        blur_type: str,
+        value: float,
+        hidden: bool = False
+    ) -> dict:
+        """
+        Create a blur effect.
+
+        Args:
+            blur_type: Type of blur ('layer-blur' or 'background-blur')
+            value: Blur amount in pixels
+            hidden: Whether blur is hidden (default: False)
+
+        Returns:
+            Blur effect dictionary
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> blur = api.create_blur('layer-blur', 10)
+        """
+        valid_types = ['layer-blur', 'background-blur']
+        if blur_type not in valid_types:
+            raise ValueError(f"Invalid blur_type '{blur_type}'. Must be one of: {', '.join(valid_types)}")
+
+        blur = {
+            'type': blur_type,
+            'value': value,
+            'hidden': hidden
+        }
+
+        return blur
+
+    def create_fill_operation(self, fills: List[dict]) -> dict:
+        """
+        Create operation to set fill(s) on object.
+
+        Args:
+            fills: List of fill dictionaries (solid colors or gradients)
+
+        Returns:
+            Set operation for fills attribute
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> gradient = api.create_gradient_fill('linear', '#ff0000', '#0000ff')
+            >>> op = api.create_fill_operation([gradient])
+        """
+        return self.create_set_operation('fills', fills)
+
+    def create_stroke_operation(self, strokes: List[dict]) -> dict:
+        """
+        Create operation to set stroke(s) on object.
+
+        Args:
+            strokes: List of stroke dictionaries
+
+        Returns:
+            Set operation for strokes attribute
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> stroke = api.create_stroke('#000000', width=2.0)
+            >>> op = api.create_stroke_operation([stroke])
+        """
+        return self.create_set_operation('strokes', strokes)
+
+    def create_shadow_operation(self, shadows: List[dict]) -> dict:
+        """
+        Create operation to set shadow(s) on object.
+
+        Args:
+            shadows: List of shadow dictionaries
+
+        Returns:
+            Set operation for shadow attribute
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> shadow = api.create_shadow('#00000080', 2, 2, 4)
+            >>> op = api.create_shadow_operation([shadow])
+        """
+        return self.create_set_operation('shadow', shadows)
+
+    def create_blur_operation(self, blur: dict) -> dict:
+        """
+        Create operation to set blur effect on object.
+
+        Args:
+            blur: Blur effect dictionary
+
+        Returns:
+            Set operation for blur attribute
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> blur = api.create_blur('layer-blur', 10)
+            >>> op = api.create_blur_operation(blur)
+        """
+        return self.create_set_operation('blur', blur)
+
     def create_file(
         self,
         name: str,

--- a/penpot_mcp/api/penpot_api.py
+++ b/penpot_mcp/api/penpot_api.py
@@ -1026,6 +1026,275 @@ class PenpotAPI:
             'pageId': page_id
         }
 
+    def create_rectangle(
+        self,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+        name: str = "Rectangle",
+        fill_color: str = "#000000",
+        fill_opacity: float = 1.0,
+        stroke_color: Optional[str] = None,
+        stroke_width: Optional[float] = None,
+        rx: float = 0,
+        ry: float = 0,
+        **kwargs
+    ) -> dict:
+        """
+        Create a rectangle shape object.
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            width: Width
+            height: Height
+            name: Shape name
+            fill_color: Fill color (hex format #RRGGBB)
+            fill_opacity: Fill opacity (0.0 to 1.0)
+            stroke_color: Optional stroke/border color
+            stroke_width: Optional stroke width
+            rx: Corner radius X
+            ry: Corner radius Y
+            **kwargs: Additional shape properties
+
+        Returns:
+            Rectangle object dictionary ready for add-obj change
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> rect = api.create_rectangle(100, 200, 300, 150, fill_color="#FF0000")
+            >>> rect_id = api.generate_session_id()
+            >>> change = api.create_add_obj_change(rect_id, "page-id", rect)
+        """
+        rect = {
+            'type': 'rect',
+            'name': name,
+            'x': x,
+            'y': y,
+            'width': width,
+            'height': height,
+            'fills': [{
+                'fillColor': fill_color,
+                'fillOpacity': fill_opacity
+            }]
+        }
+
+        if rx > 0 or ry > 0:
+            rect['rx'] = rx
+            rect['ry'] = ry
+
+        if stroke_color and stroke_width:
+            rect['strokes'] = [{
+                'strokeColor': stroke_color,
+                'strokeWidth': stroke_width
+            }]
+
+        # Merge any additional kwargs
+        rect.update(kwargs)
+
+        return rect
+
+    def create_circle(
+        self,
+        cx: float,
+        cy: float,
+        radius: float,
+        name: str = "Circle",
+        fill_color: str = "#000000",
+        fill_opacity: float = 1.0,
+        stroke_color: Optional[str] = None,
+        stroke_width: Optional[float] = None,
+        **kwargs
+    ) -> dict:
+        """
+        Create a circle/ellipse shape object.
+
+        Args:
+            cx: Center X coordinate
+            cy: Center Y coordinate
+            radius: Radius (for circle) or use width/height for ellipse
+            name: Shape name
+            fill_color: Fill color
+            fill_opacity: Fill opacity
+            stroke_color: Optional stroke color
+            stroke_width: Optional stroke width
+            **kwargs: Additional properties (e.g., width, height for ellipse)
+
+        Returns:
+            Circle object dictionary
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> circle = api.create_circle(150, 150, 50, fill_color="#00FF00")
+            >>> circle_id = api.generate_session_id()
+            >>> change = api.create_add_obj_change(circle_id, "page-id", circle)
+        """
+        # Circle is positioned by top-left corner in Penpot
+        circle = {
+            'type': 'circle',
+            'name': name,
+            'x': cx - radius,
+            'y': cy - radius,
+            'width': radius * 2,
+            'height': radius * 2,
+            'fills': [{
+                'fillColor': fill_color,
+                'fillOpacity': fill_opacity
+            }]
+        }
+
+        if stroke_color and stroke_width:
+            circle['strokes'] = [{
+                'strokeColor': stroke_color,
+                'strokeWidth': stroke_width
+            }]
+
+        circle.update(kwargs)
+
+        return circle
+
+    def create_text(
+        self,
+        x: float,
+        y: float,
+        content: str,
+        name: str = "Text",
+        font_size: int = 16,
+        font_family: str = "Work Sans",
+        fill_color: str = "#000000",
+        font_weight: str = "normal",
+        text_align: str = "left",
+        **kwargs
+    ) -> dict:
+        """
+        Create a text shape object.
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            content: Text content
+            name: Shape name
+            font_size: Font size in pixels
+            font_family: Font family name
+            fill_color: Text color
+            font_weight: Font weight (normal, bold, etc.)
+            text_align: Text alignment (left, center, right)
+            **kwargs: Additional properties
+
+        Returns:
+            Text object dictionary
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> text = api.create_text(10, 20, "Hello World", font_size=24)
+            >>> text_id = api.generate_session_id()
+            >>> change = api.create_add_obj_change(text_id, "page-id", text)
+        """
+        text = {
+            'type': 'text',
+            'name': name,
+            'x': x,
+            'y': y,
+            'content': content,
+            'fills': [{
+                'fillColor': fill_color,
+                'fillOpacity': 1.0
+            }],
+            'fontSize': font_size,
+            'fontFamily': font_family,
+            'fontWeight': font_weight,
+            'textAlign': text_align
+        }
+
+        text.update(kwargs)
+
+        return text
+
+    def create_frame(
+        self,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+        name: str = "Frame",
+        background_color: Optional[str] = None,
+        **kwargs
+    ) -> dict:
+        """
+        Create a frame (artboard) object.
+
+        Frames are containers for other objects, similar to artboards.
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            width: Width
+            height: Height
+            name: Frame name
+            background_color: Optional background color
+            **kwargs: Additional properties
+
+        Returns:
+            Frame object dictionary
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> frame = api.create_frame(0, 0, 375, 812, name="iPhone", background_color="#FFFFFF")
+            >>> frame_id = api.generate_session_id()
+            >>> change = api.create_add_obj_change(frame_id, "page-id", frame)
+        """
+        frame = {
+            'type': 'frame',
+            'name': name,
+            'x': x,
+            'y': y,
+            'width': width,
+            'height': height
+        }
+
+        if background_color:
+            frame['fills'] = [{
+                'fillColor': background_color,
+                'fillOpacity': 1.0
+            }]
+
+        frame.update(kwargs)
+
+        return frame
+
+    def create_group(
+        self,
+        name: str = "Group",
+        **kwargs
+    ) -> dict:
+        """
+        Create a group container object.
+
+        Groups are containers that organize multiple objects.
+
+        Args:
+            name: Group name
+            **kwargs: Additional properties
+
+        Returns:
+            Group object dictionary
+
+        Example:
+            >>> api = PenpotAPI()
+            >>> group = api.create_group(name="My Group")
+            >>> group_id = api.generate_session_id()
+            >>> change = api.create_add_obj_change(group_id, "page-id", group)
+        """
+        group = {
+            'type': 'group',
+            'name': name
+        }
+
+        group.update(kwargs)
+
+        return group
+
     def create_file(
         self,
         name: str,

--- a/penpot_mcp/api/penpot_api.py
+++ b/penpot_mcp/api/penpot_api.py
@@ -641,7 +641,8 @@ class PenpotAPI:
             file_id: UUID of the file to delete
 
         Returns:
-            Success confirmation or error details
+            Success confirmation. If API returns empty response,
+            returns {"success": True, "id": file_id}
 
         Example:
             >>> api = PenpotAPI()

--- a/penpot_mcp/api/penpot_api.py
+++ b/penpot_mcp/api/penpot_api.py
@@ -1259,12 +1259,15 @@ def main():
             print(f"- {project.get('name')} - {project.get('teamName')} (ID: {project.get('id')})")
 
     elif args.command == 'get-project':
-        project = api.get_project(args.id)
-        if project:
+        try:
+            project = api.get_project(args.id)
             print(f"Project: {project.get('name')}")
             print(json.dumps(project, indent=2))
-        else:
-            print(f"Project not found: {args.id}")
+        except requests.HTTPError as e:
+            if e.response and e.response.status_code == 404:
+                print(f"Project not found: {args.id}")
+            else:
+                print(f"Error retrieving project: {e}")
 
     elif args.command == 'list-files':
         files = api.get_project_files(args.project_id)

--- a/penpot_mcp/server/mcp_server.py
+++ b/penpot_mcp/server/mcp_server.py
@@ -213,6 +213,82 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
                 return file_data
             except Exception as e:
                 return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def create_file(
+            name: str,
+            project_id: str,
+            is_shared: bool = False
+        ) -> dict:
+            """Create a new Penpot design file."""
+            try:
+                result = self.api.create_file(name, project_id, is_shared)
+                # Cache the newly created file
+                self.file_cache.set(result['id'], result)
+                return result
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def delete_file(file_id: str) -> dict:
+            """Delete a Penpot file."""
+            try:
+                result = self.api.delete_file(file_id)
+                # Remove from cache if present
+                if file_id in self.file_cache._cache:
+                    del self.file_cache._cache[file_id]
+                return result
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def rename_file(file_id: str, name: str) -> dict:
+            """Rename a Penpot file."""
+            try:
+                result = self.api.rename_file(file_id, name)
+                # Update cache if present
+                if file_id in self.file_cache._cache:
+                    self.file_cache._cache[file_id]['data']['name'] = name
+                return result
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def list_teams() -> dict:
+            """List all teams the user has access to."""
+            try:
+                teams = self.api.get_teams()
+                return {"teams": teams}
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def create_project(name: str, team_id: str) -> dict:
+            """Create a new project within a team."""
+            try:
+                result = self.api.create_project(name, team_id)
+                return result
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def rename_project(project_id: str, name: str) -> dict:
+            """Rename a project."""
+            try:
+                result = self.api.rename_project(project_id, name)
+                return result
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def delete_project(project_id: str) -> dict:
+            """Delete a project and all its files. WARNING: Permanent deletion!"""
+            try:
+                result = self.api.delete_project(project_id)
+                return result
+            except Exception as e:
+                return self._handle_api_error(e)
+        
         @self.mcp.tool()
         def export_object(
                 file_id: str,

--- a/penpot_mcp/server/mcp_server.py
+++ b/penpot_mcp/server/mcp_server.py
@@ -220,7 +220,20 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
             project_id: str,
             is_shared: bool = False
         ) -> dict:
-            """Create a new Penpot design file."""
+            """
+            Create a new Penpot design file.
+            
+            Args:
+                name: Name for the new file
+                project_id: ID of the project to create the file in
+                is_shared: Whether the file should be shared (default: False)
+            
+            Returns:
+                Created file information including file ID
+            
+            Example:
+                create_file(name="Login Screen", project_id="abc-123")
+            """
             try:
                 result = self.api.create_file(name, project_id, is_shared)
                 # Cache the newly created file
@@ -231,7 +244,18 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
         
         @self.mcp.tool()
         def delete_file(file_id: str) -> dict:
-            """Delete a Penpot file."""
+            """
+            Delete a Penpot file.
+            
+            Args:
+                file_id: ID of the file to delete
+            
+            Returns:
+                Deletion confirmation
+            
+            Example:
+                delete_file(file_id="abc-123")
+            """
             try:
                 result = self.api.delete_file(file_id)
                 # Remove from cache if present
@@ -243,7 +267,19 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
         
         @self.mcp.tool()
         def rename_file(file_id: str, name: str) -> dict:
-            """Rename a Penpot file."""
+            """
+            Rename a Penpot file.
+            
+            Args:
+                file_id: ID of the file to rename
+                name: New name for the file
+            
+            Returns:
+                Updated file information
+            
+            Example:
+                rename_file(file_id="abc-123", name="Updated Design")
+            """
             try:
                 result = self.api.rename_file(file_id, name)
                 # Update cache if present
@@ -255,7 +291,15 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
         
         @self.mcp.tool()
         def list_teams() -> dict:
-            """List all teams the user has access to."""
+            """
+            List all teams the user has access to.
+            
+            Returns:
+                Dictionary containing list of teams
+            
+            Example:
+                list_teams()
+            """
             try:
                 teams = self.api.get_teams()
                 return {"teams": teams}
@@ -264,7 +308,19 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
         
         @self.mcp.tool()
         def create_project(name: str, team_id: str) -> dict:
-            """Create a new project within a team."""
+            """
+            Create a new project within a team.
+            
+            Args:
+                name: Name for the new project
+                team_id: ID of the team to create the project in
+            
+            Returns:
+                Created project information including project ID
+            
+            Example:
+                create_project(name="Mobile App", team_id="team-123")
+            """
             try:
                 result = self.api.create_project(name, team_id)
                 return result
@@ -273,7 +329,19 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
         
         @self.mcp.tool()
         def rename_project(project_id: str, name: str) -> dict:
-            """Rename a project."""
+            """
+            Rename a project.
+            
+            Args:
+                project_id: ID of the project to rename
+                name: New name for the project
+            
+            Returns:
+                Updated project information
+            
+            Example:
+                rename_project(project_id="proj-123", name="Redesign 2024")
+            """
             try:
                 result = self.api.rename_project(project_id, name)
                 return result
@@ -282,7 +350,20 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
         
         @self.mcp.tool()
         def delete_project(project_id: str) -> dict:
-            """Delete a project and all its files. WARNING: Permanent deletion!"""
+            """
+            Delete a project and all its files.
+            
+            WARNING: This is a permanent deletion operation!
+            
+            Args:
+                project_id: ID of the project to delete
+            
+            Returns:
+                Deletion confirmation
+            
+            Example:
+                delete_project(project_id="proj-123")
+            """
             try:
                 result = self.api.delete_project(project_id)
                 return result

--- a/penpot_mcp/server/mcp_server.py
+++ b/penpot_mcp/server/mcp_server.py
@@ -1434,6 +1434,120 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
             except Exception as e:
                 return self._handle_api_error(e)
 
+        # ========== COMMENT & COLLABORATION TOOLS ==========
+
+        @self.mcp.tool()
+        def add_design_comment(
+            file_id: str,
+            page_id: str,
+            x: float,
+            y: float,
+            comment: str,
+            frame_id: Optional[str] = None
+        ) -> dict:
+            """
+            Add a comment to a design at a specific location.
+
+            Args:
+                file_id: ID of the Penpot file
+                page_id: ID of the page
+                x: X position for comment marker
+                y: Y position for comment marker
+                comment: Comment text
+                frame_id: Optional frame ID if commenting within a frame
+
+            Returns:
+                Created comment thread information
+
+            Example:
+                add_design_comment(
+                    file_id="abc-123",
+                    page_id="page-1",
+                    x=150, y=200,
+                    comment="This heading should use our brand font"
+                )
+            """
+            try:
+                thread = self.api.create_comment_thread(
+                    file_id, page_id, x, y, comment, frame_id
+                )
+                return {"success": True, "thread_id": thread.get('id'), "thread": thread}
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def reply_to_comment(
+            thread_id: str,
+            reply: str
+        ) -> dict:
+            """
+            Reply to an existing comment thread.
+
+            Args:
+                thread_id: ID of the comment thread
+                reply: Reply text
+
+            Returns:
+                Created comment information
+
+            Example:
+                reply_to_comment(
+                    thread_id="thread-123",
+                    reply="Done! Updated the font to Roboto Bold"
+                )
+            """
+            try:
+                comment = self.api.add_comment(thread_id, reply)
+                return {"success": True, "comment_id": comment.get('id'), "comment": comment}
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def get_file_comments(
+            file_id: str,
+            page_id: Optional[str] = None
+        ) -> dict:
+            """
+            Get all comment threads for a file or specific page.
+
+            Args:
+                file_id: ID of the Penpot file
+                page_id: Optional ID of specific page
+
+            Returns:
+                List of comment threads with their positions and content
+
+            Example:
+                get_file_comments(file_id="abc-123", page_id="page-1")
+            """
+            try:
+                threads = self.api.get_comment_threads(file_id, page_id)
+                return {"success": True, "count": len(threads), "threads": threads}
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def resolve_comment_thread(
+            thread_id: str
+        ) -> dict:
+            """
+            Mark a comment thread as resolved.
+
+            Args:
+                thread_id: ID of the comment thread
+
+            Returns:
+                Updated thread information
+
+            Example:
+                resolve_comment_thread(thread_id="thread-123")
+            """
+            try:
+                thread = self.api.update_comment_thread_status(thread_id, is_resolved=True)
+                return {"success": True, "thread": thread}
+            except Exception as e:
+                return self._handle_api_error(e)
+
         if include_resource_tools:
             @self.mcp.tool()
             def penpot_schema() -> dict:

--- a/penpot_mcp/server/mcp_server.py
+++ b/penpot_mcp/server/mcp_server.py
@@ -424,6 +424,246 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
                         os.remove(temp_filename)
                     except Exception as e:
                         print(f"Warning: Failed to delete temporary file {temp_filename}: {str(e)}")
+        
+        @self.mcp.tool()
+        def move_object(
+            file_id: str,
+            object_id: str,
+            x: float,
+            y: float
+        ) -> dict:
+            """
+            Move an object to a new position.
+
+            Args:
+                file_id: ID of the file
+                object_id: ID of the object to move
+                x: New X coordinate
+                y: New Y coordinate
+
+            Returns:
+                Success result with new revision
+
+            Example:
+                move_object(file_id="file-123", object_id="obj-456", x=200, y=150)
+            """
+            try:
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    # Create modification operations
+                    ops = [
+                        self.api.create_set_operation('x', x),
+                        self.api.create_set_operation('y', y)
+                    ]
+
+                    # Create modify change
+                    change = self.api.create_mod_obj_change(object_id, ops)
+
+                    # Apply change
+                    result = self.api.update_file(file_id, session_id, revn, [change])
+
+                    return {
+                        "success": True,
+                        "objectId": object_id,
+                        "revn": result.get('revn')
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def resize_object(
+            file_id: str,
+            object_id: str,
+            width: float,
+            height: float
+        ) -> dict:
+            """
+            Resize an object.
+
+            Args:
+                file_id: ID of the file
+                object_id: ID of the object to resize
+                width: New width
+                height: New height
+
+            Returns:
+                Success result
+
+            Example:
+                resize_object(file_id="file-123", object_id="obj-456", width=300, height=200)
+            """
+            try:
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    ops = [
+                        self.api.create_set_operation('width', width),
+                        self.api.create_set_operation('height', height)
+                    ]
+
+                    change = self.api.create_mod_obj_change(object_id, ops)
+                    result = self.api.update_file(file_id, session_id, revn, [change])
+
+                    return {
+                        "success": True,
+                        "objectId": object_id,
+                        "revn": result.get('revn')
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def change_object_color(
+            file_id: str,
+            object_id: str,
+            fill_color: str,
+            fill_opacity: float = 1.0
+        ) -> dict:
+            """
+            Change the fill color of an object.
+
+            Args:
+                file_id: ID of the file
+                object_id: ID of the object
+                fill_color: New fill color (hex format, e.g., #FF0000)
+                fill_opacity: Fill opacity (0.0 to 1.0)
+
+            Returns:
+                Success result
+
+            Example:
+                change_object_color(file_id="file-123", object_id="obj-456", fill_color="#FF0000")
+            """
+            try:
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    # Set new fill
+                    fills = [{
+                        'fillColor': fill_color,
+                        'fillOpacity': fill_opacity
+                    }]
+
+                    ops = [
+                        self.api.create_set_operation('fills', fills)
+                    ]
+
+                    change = self.api.create_mod_obj_change(object_id, ops)
+                    result = self.api.update_file(file_id, session_id, revn, [change])
+
+                    return {
+                        "success": True,
+                        "objectId": object_id,
+                        "revn": result.get('revn')
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def rotate_object(
+            file_id: str,
+            object_id: str,
+            rotation: float
+        ) -> dict:
+            """
+            Rotate an object.
+
+            Args:
+                file_id: ID of the file
+                object_id: ID of the object
+                rotation: Rotation angle in degrees (0-360)
+
+            Returns:
+                Success result
+
+            Example:
+                rotate_object(file_id="file-123", object_id="obj-456", rotation=45)
+            """
+            try:
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    ops = [
+                        self.api.create_set_operation('rotation', rotation)
+                    ]
+
+                    change = self.api.create_mod_obj_change(object_id, ops)
+                    result = self.api.update_file(file_id, session_id, revn, [change])
+
+                    return {
+                        "success": True,
+                        "objectId": object_id,
+                        "revn": result.get('revn')
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def delete_object(
+            file_id: str,
+            page_id: str,
+            object_id: str
+        ) -> dict:
+            """
+            Delete an object from the design.
+
+            Args:
+                file_id: ID of the file
+                page_id: ID of the page containing the object
+                object_id: ID of the object to delete
+
+            Returns:
+                Success result
+
+            Example:
+                delete_object(file_id="file-123", page_id="page-456", object_id="obj-789")
+            """
+            try:
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    # Create delete change
+                    change = self.api.create_del_obj_change(object_id, page_id)
+
+                    # Apply change
+                    result = self.api.update_file(file_id, session_id, revn, [change])
+
+                    return {
+                        "success": True,
+                        "deletedObjectId": object_id,
+                        "revn": result.get('revn')
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+        
+        @self.mcp.tool()
+        def apply_design_changes(
+            file_id: str,
+            changes: List[dict]
+        ) -> dict:
+            """
+            Apply multiple design changes atomically.
+
+            This is a power tool for complex multi-step operations.
+
+            Args:
+                file_id: ID of the file
+                changes: List of change operations (from change builders)
+
+            Returns:
+                Success result
+
+            Example:
+                changes = [
+                    {"type": "add-obj", "id": "obj-1", "pageId": "page-1", "obj": {...}},
+                    {"type": "mod-obj", "id": "obj-2", "operations": [...]},
+                    {"type": "del-obj", "id": "obj-3", "pageId": "page-1"}
+                ]
+                apply_design_changes(file_id="file-123", changes=changes)
+            """
+            try:
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    result = self.api.update_file(file_id, session_id, revn, changes)
+
+                    return {
+                        "success": True,
+                        "revn": result.get('revn'),
+                        "changesApplied": len(changes)
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+        
         @self.mcp.tool()
         def get_object_tree(
             file_id: str, 

--- a/penpot_mcp/server/mcp_server.py
+++ b/penpot_mcp/server/mcp_server.py
@@ -1689,6 +1689,61 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
             except Exception as e:
                 return self._handle_api_error(e)
 
+        @self.mcp.tool()
+        def unpublish_library(
+            file_id: str
+        ) -> dict:
+            """
+            Unpublish a file as a library.
+
+            Removes the library status from a file, making its components
+            no longer available for use in other files.
+
+            Args:
+                file_id: ID of the file to unpublish
+
+            Returns:
+                Updated file information
+
+            Example:
+                unpublish_library(file_id="abc-123")
+            """
+            try:
+                result = self.api.publish_library(file_id, publish=False)
+                return {"success": True, "file": result}
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def get_file_libraries(
+            file_id: str
+        ) -> dict:
+            """
+            Get all libraries linked to a file.
+
+            Returns a list of all component libraries that are currently
+            linked to the specified file, allowing you to discover which
+            libraries' components are available for use.
+
+            Args:
+                file_id: ID of the file
+
+            Returns:
+                List of linked libraries with their information
+
+            Example:
+                get_file_libraries(file_id="abc-123")
+            """
+            try:
+                libraries = self.api.get_file_libraries(file_id)
+                return {
+                    "success": True,
+                    "count": len(libraries),
+                    "libraries": libraries
+                }
+            except Exception as e:
+                return self._handle_api_error(e)
+
         if include_resource_tools:
             @self.mcp.tool()
             def penpot_schema() -> dict:

--- a/penpot_mcp/server/mcp_server.py
+++ b/penpot_mcp/server/mcp_server.py
@@ -1548,6 +1548,147 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
             except Exception as e:
                 return self._handle_api_error(e)
 
+        @self.mcp.tool()
+        def link_library(
+            file_id: str,
+            library_id: str
+        ) -> dict:
+            """
+            Link a file to a component library.
+
+            Args:
+                file_id: ID of the file
+                library_id: ID of the library file to link
+
+            Returns:
+                Success confirmation
+
+            Example:
+                link_library(file_id="abc-123", library_id="lib-456")
+            """
+            try:
+                result = self.api.link_file_to_library(file_id, library_id)
+                return {"success": True, "result": result}
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def list_library_components(
+            library_id: str
+        ) -> dict:
+            """
+            List all components available in a library.
+
+            Args:
+                library_id: ID of the library file
+
+            Returns:
+                List of components with their names and IDs
+
+            Example:
+                list_library_components(library_id="lib-456")
+            """
+            try:
+                components = self.api.get_library_components(library_id)
+                return {
+                    "success": True,
+                    "count": len(components),
+                    "components": components
+                }
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def import_component(
+            file_id: str,
+            page_id: str,
+            library_id: str,
+            component_id: str,
+            x: float,
+            y: float,
+            frame_id: Optional[str] = None
+        ) -> dict:
+            """
+            Import a component from a library into the design.
+
+            Args:
+                file_id: ID of the target file
+                page_id: ID of the target page
+                library_id: ID of the library file
+                component_id: ID of the component to import
+                x: X position for the component instance
+                y: Y position for the component instance
+                frame_id: Optional parent frame ID
+
+            Returns:
+                Created component instance information
+
+            Example:
+                import_component(
+                    file_id="abc-123",
+                    page_id="page-1",
+                    library_id="lib-456",
+                    component_id="button-primary",
+                    x=100, y=100
+                )
+            """
+            try:
+                result = self.api.instantiate_component(
+                    file_id, page_id, library_id, component_id, x, y, frame_id
+                )
+                return {"success": True, "file": result}
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def sync_library(
+            file_id: str,
+            library_id: str
+        ) -> dict:
+            """
+            Synchronize component instances with their library.
+
+            Updates all instances of components from the library to match
+            the current library version.
+
+            Args:
+                file_id: ID of the file
+                library_id: ID of the library to sync
+
+            Returns:
+                Sync result with count of updated instances
+
+            Example:
+                sync_library(file_id="abc-123", library_id="lib-456")
+            """
+            try:
+                result = self.api.sync_file_library(file_id, library_id)
+                return {"success": True, "result": result}
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def publish_as_library(
+            file_id: str
+        ) -> dict:
+            """
+            Publish a file as a shared component library.
+
+            Args:
+                file_id: ID of the file to publish
+
+            Returns:
+                Updated file information
+
+            Example:
+                publish_as_library(file_id="abc-123")
+            """
+            try:
+                result = self.api.publish_library(file_id, publish=True)
+                return {"success": True, "file": result}
+            except Exception as e:
+                return self._handle_api_error(e)
+
         if include_resource_tools:
             @self.mcp.tool()
             def penpot_schema() -> dict:

--- a/penpot_mcp/server/mcp_server.py
+++ b/penpot_mcp/server/mcp_server.py
@@ -524,6 +524,247 @@ Let me know which Penpot design you'd like to convert to code, and I'll guide yo
                 return {'objects': matches}
             except Exception as e:
                 return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def add_rectangle(
+            file_id: str,
+            page_id: str,
+            x: float,
+            y: float,
+            width: float,
+            height: float,
+            name: str = "Rectangle",
+            fill_color: str = "#000000",
+            stroke_color: Optional[str] = None,
+            stroke_width: Optional[float] = None,
+            frame_id: Optional[str] = None
+        ) -> dict:
+            """
+            Add a rectangle to the design.
+
+            Args:
+                file_id: ID of the file to add to
+                page_id: ID of the page to add to
+                x: X coordinate
+                y: Y coordinate
+                width: Rectangle width
+                height: Rectangle height
+                name: Name for the rectangle
+                fill_color: Fill color (hex format, e.g., #FF0000)
+                stroke_color: Optional border color
+                stroke_width: Optional border width
+                frame_id: Optional parent frame ID
+
+            Returns:
+                Result with created object ID
+
+            Example:
+                add_rectangle(
+                    file_id="file-123",
+                    page_id="page-456",
+                    x=100, y=100,
+                    width=200, height=150,
+                    fill_color="#FF0000"
+                )
+            """
+            try:
+                # Generate ID for new object
+                obj_id = self.api.generate_session_id()
+
+                # Get session and revision
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    # Create rectangle object
+                    rect = self.api.create_rectangle(
+                        x, y, width, height,
+                        name=name,
+                        fill_color=fill_color,
+                        stroke_color=stroke_color,
+                        stroke_width=stroke_width
+                    )
+
+                    # Create add change
+                    change = self.api.create_add_obj_change(
+                        obj_id, page_id, rect, frame_id=frame_id
+                    )
+
+                    # Apply change
+                    result = self.api.update_file(file_id, session_id, revn, [change])
+
+                    return {
+                        "success": True,
+                        "objectId": obj_id,
+                        "revn": result.get('revn')
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def add_circle(
+            file_id: str,
+            page_id: str,
+            cx: float,
+            cy: float,
+            radius: float,
+            name: str = "Circle",
+            fill_color: str = "#000000",
+            stroke_color: Optional[str] = None,
+            stroke_width: Optional[float] = None,
+            frame_id: Optional[str] = None
+        ) -> dict:
+            """
+            Add a circle to the design.
+
+            Args:
+                file_id: ID of the file
+                page_id: ID of the page
+                cx: Center X coordinate
+                cy: Center Y coordinate
+                radius: Circle radius
+                name: Name for the circle
+                fill_color: Fill color
+                stroke_color: Optional border color
+                stroke_width: Optional border width
+                frame_id: Optional parent frame ID
+
+            Returns:
+                Result with created object ID
+            """
+            try:
+                obj_id = self.api.generate_session_id()
+
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    circle = self.api.create_circle(
+                        cx, cy, radius,
+                        name=name,
+                        fill_color=fill_color,
+                        stroke_color=stroke_color,
+                        stroke_width=stroke_width
+                    )
+
+                    change = self.api.create_add_obj_change(
+                        obj_id, page_id, circle, frame_id=frame_id
+                    )
+
+                    result = self.api.update_file(file_id, session_id, revn, [change])
+
+                    return {
+                        "success": True,
+                        "objectId": obj_id,
+                        "revn": result.get('revn')
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def add_text(
+            file_id: str,
+            page_id: str,
+            x: float,
+            y: float,
+            content: str,
+            name: str = "Text",
+            font_size: int = 16,
+            fill_color: str = "#000000",
+            font_family: str = "Work Sans",
+            frame_id: Optional[str] = None
+        ) -> dict:
+            """
+            Add text to the design.
+
+            Args:
+                file_id: ID of the file
+                page_id: ID of the page
+                x: X coordinate
+                y: Y coordinate
+                content: Text content
+                name: Name for the text object
+                font_size: Font size in pixels
+                fill_color: Text color
+                font_family: Font family name
+                frame_id: Optional parent frame ID
+
+            Returns:
+                Result with created object ID
+            """
+            try:
+                obj_id = self.api.generate_session_id()
+
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    text = self.api.create_text(
+                        x, y, content,
+                        name=name,
+                        font_size=font_size,
+                        fill_color=fill_color,
+                        font_family=font_family
+                    )
+
+                    change = self.api.create_add_obj_change(
+                        obj_id, page_id, text, frame_id=frame_id
+                    )
+
+                    result = self.api.update_file(file_id, session_id, revn, [change])
+
+                    return {
+                        "success": True,
+                        "objectId": obj_id,
+                        "revn": result.get('revn')
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+
+        @self.mcp.tool()
+        def add_frame(
+            file_id: str,
+            page_id: str,
+            x: float,
+            y: float,
+            width: float,
+            height: float,
+            name: str = "Frame",
+            background_color: Optional[str] = None
+        ) -> dict:
+            """
+            Create a new frame (artboard) in the design.
+
+            Frames act as containers for other objects.
+
+            Args:
+                file_id: ID of the file
+                page_id: ID of the page
+                x: X coordinate
+                y: Y coordinate
+                width: Frame width
+                height: Frame height
+                name: Name for the frame
+                background_color: Optional background color
+
+            Returns:
+                Result with created frame ID
+            """
+            try:
+                obj_id = self.api.generate_session_id()
+
+                with self.api.editing_session(file_id) as (session_id, revn):
+                    frame = self.api.create_frame(
+                        x, y, width, height,
+                        name=name,
+                        background_color=background_color
+                    )
+
+                    change = self.api.create_add_obj_change(
+                        obj_id, page_id, frame
+                    )
+
+                    result = self.api.update_file(file_id, session_id, revn, [change])
+
+                    return {
+                        "success": True,
+                        "frameId": obj_id,
+                        "revn": result.get('revn')
+                    }
+            except Exception as e:
+                return self._handle_api_error(e)
+
         if include_resource_tools:
             @self.mcp.tool()
             def penpot_schema() -> dict:

--- a/tests/test_advanced_shapes.py
+++ b/tests/test_advanced_shapes.py
@@ -1,0 +1,342 @@
+"""Tests for advanced shape creation helper methods."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from penpot_mcp.api.penpot_api import PenpotAPI
+
+
+@pytest.fixture
+def api_client():
+    """Create a PenpotAPI client for testing."""
+    with patch.object(PenpotAPI, 'login_with_password'):
+        api = PenpotAPI(debug=False)
+        api.access_token = "test-token"
+        return api
+
+
+class TestCreatePath:
+    """Tests for create_path method."""
+
+    def test_create_path_basic(self, api_client):
+        """Test basic path creation with triangle."""
+        points = [
+            {'x': 50, 'y': 0},
+            {'x': 100, 'y': 100},
+            {'x': 0, 'y': 100}
+        ]
+        path = api_client.create_path(points, fill_color='#ff0000')
+
+        assert path['type'] == 'path'
+        assert path['name'] == 'Path'
+        assert 'content' in path
+        assert len(path['content']) == 4  # M, L, L, Z
+        assert path['content'][0]['command'] == 'M'
+        assert path['content'][1]['command'] == 'L'
+        assert path['content'][2]['command'] == 'L'
+        assert path['content'][3]['command'] == 'Z'
+        assert 'fills' in path
+        assert path['fills'][0]['fillColor'] == '#ff0000'
+
+    def test_create_path_open(self, api_client):
+        """Test open path (not closed)."""
+        points = [
+            {'x': 0, 'y': 0},
+            {'x': 100, 'y': 0}
+        ]
+        path = api_client.create_path(points, closed=False)
+
+        assert len(path['content']) == 2  # M, L (no Z)
+        assert path['content'][0]['command'] == 'M'
+        assert path['content'][1]['command'] == 'L'
+
+    def test_create_path_with_stroke(self, api_client):
+        """Test path with stroke."""
+        points = [
+            {'x': 0, 'y': 0},
+            {'x': 100, 'y': 0},
+            {'x': 100, 'y': 100}
+        ]
+        path = api_client.create_path(
+            points,
+            stroke_color='#0000ff',
+            stroke_width=2.5
+        )
+
+        assert 'strokes' in path
+        assert len(path['strokes']) == 1
+        assert path['strokes'][0]['strokeColor'] == '#0000ff'
+        assert path['strokes'][0]['strokeWidth'] == 2.5
+
+    def test_create_path_without_fill(self, api_client):
+        """Test path without fill."""
+        points = [
+            {'x': 0, 'y': 0},
+            {'x': 100, 'y': 0}
+        ]
+        path = api_client.create_path(points)
+
+        assert 'fills' not in path
+
+    def test_create_path_custom_name(self, api_client):
+        """Test path with custom name."""
+        points = [
+            {'x': 0, 'y': 0},
+            {'x': 100, 'y': 0}
+        ]
+        path = api_client.create_path(points, name="My Path")
+
+        assert path['name'] == "My Path"
+
+    def test_create_path_bounding_box(self, api_client):
+        """Test path calculates correct bounding box."""
+        points = [
+            {'x': 10, 'y': 20},
+            {'x': 110, 'y': 120},
+            {'x': 60, 'y': 70}
+        ]
+        path = api_client.create_path(points)
+
+        assert path['x'] == 10
+        assert path['y'] == 20
+        assert path['width'] == 100
+        assert path['height'] == 100
+
+    def test_create_path_with_kwargs(self, api_client):
+        """Test path with additional properties via kwargs."""
+        points = [
+            {'x': 0, 'y': 0},
+            {'x': 100, 'y': 0}
+        ]
+        path = api_client.create_path(
+            points,
+            custom_property="custom_value"
+        )
+
+        assert path['custom_property'] == "custom_value"
+
+    def test_create_path_requires_at_least_two_points(self, api_client):
+        """Test path creation fails with less than 2 points."""
+        with pytest.raises(ValueError, match="at least 2 points"):
+            api_client.create_path([{'x': 0, 'y': 0}])
+
+        with pytest.raises(ValueError, match="at least 2 points"):
+            api_client.create_path([])
+
+
+class TestCreateBooleanShape:
+    """Tests for create_boolean_shape method."""
+
+    def test_create_boolean_shape_union(self, api_client):
+        """Test boolean union shape creation."""
+        bool_shape = api_client.create_boolean_shape(
+            operation='union',
+            shapes=['obj-1', 'obj-2']
+        )
+
+        assert bool_shape['type'] == 'bool'
+        assert bool_shape['bool-type'] == 'union'
+        assert len(bool_shape['shapes']) == 2
+        assert bool_shape['shapes'][0] == 'obj-1'
+        assert bool_shape['shapes'][1] == 'obj-2'
+
+    def test_create_boolean_shape_difference(self, api_client):
+        """Test boolean difference shape creation."""
+        bool_shape = api_client.create_boolean_shape(
+            operation='difference',
+            shapes=['obj-1', 'obj-2', 'obj-3']
+        )
+
+        assert bool_shape['bool-type'] == 'difference'
+        assert len(bool_shape['shapes']) == 3
+
+    def test_create_boolean_shape_intersection(self, api_client):
+        """Test boolean intersection shape creation."""
+        bool_shape = api_client.create_boolean_shape(
+            operation='intersection',
+            shapes=['obj-1', 'obj-2']
+        )
+
+        assert bool_shape['bool-type'] == 'intersection'
+
+    def test_create_boolean_shape_exclusion(self, api_client):
+        """Test boolean exclusion shape creation."""
+        bool_shape = api_client.create_boolean_shape(
+            operation='exclusion',
+            shapes=['obj-1', 'obj-2']
+        )
+
+        assert bool_shape['bool-type'] == 'exclusion'
+
+    def test_create_boolean_shape_custom_name(self, api_client):
+        """Test boolean shape with custom name."""
+        bool_shape = api_client.create_boolean_shape(
+            operation='union',
+            shapes=['obj-1', 'obj-2'],
+            name="My Boolean"
+        )
+
+        assert bool_shape['name'] == "My Boolean"
+
+    def test_create_boolean_shape_with_kwargs(self, api_client):
+        """Test boolean shape with additional properties via kwargs."""
+        bool_shape = api_client.create_boolean_shape(
+            operation='union',
+            shapes=['obj-1', 'obj-2'],
+            custom_property="custom_value"
+        )
+
+        assert bool_shape['custom_property'] == "custom_value"
+
+    def test_create_boolean_shape_invalid_operation(self, api_client):
+        """Test boolean shape creation fails with invalid operation."""
+        with pytest.raises(ValueError, match="Invalid operation"):
+            api_client.create_boolean_shape(
+                operation='invalid',
+                shapes=['obj-1', 'obj-2']
+            )
+
+    def test_create_boolean_shape_requires_at_least_two_shapes(self, api_client):
+        """Test boolean shape creation fails with less than 2 shapes."""
+        with pytest.raises(ValueError, match="at least 2 shapes"):
+            api_client.create_boolean_shape(
+                operation='union',
+                shapes=['obj-1']
+            )
+
+        with pytest.raises(ValueError, match="at least 2 shapes"):
+            api_client.create_boolean_shape(
+                operation='union',
+                shapes=[]
+            )
+
+
+class TestCreateParentOperation:
+    """Tests for create_parent_operation method."""
+
+    def test_create_parent_operation_basic(self, api_client):
+        """Test parent operation creation."""
+        op = api_client.create_parent_operation('group-123')
+
+        assert op['type'] == 'set'
+        assert op['attr'] == 'parentId'
+        assert op['val'] == 'group-123'
+
+    def test_create_parent_operation_different_parent(self, api_client):
+        """Test parent operation with different parent ID."""
+        op = api_client.create_parent_operation('frame-456')
+
+        assert op['val'] == 'frame-456'
+
+
+class TestAdvancedShapeIntegration:
+    """Integration tests for advanced shape helpers with change builders."""
+
+    def test_create_path_and_add_to_file(self, api_client):
+        """Test complete workflow: create path and add to file."""
+        # Create path
+        points = [
+            {'x': 0, 'y': 0},
+            {'x': 100, 'y': 0},
+            {'x': 50, 'y': 100}
+        ]
+        path = api_client.create_path(points, fill_color='#00ff00')
+
+        # Create add-obj change
+        change = api_client.create_add_obj_change('path-1', 'page-1', path)
+
+        assert change['type'] == 'add-obj'
+        assert change['id'] == 'path-1'
+        assert change['obj']['type'] == 'path'
+        assert len(change['obj']['content']) == 4
+
+    def test_group_multiple_objects(self, api_client):
+        """Test creating group and adding objects to it."""
+        # Create group
+        group = api_client.create_group(name="Button Group")
+        group_change = api_client.create_add_obj_change('group-1', 'page-1', group)
+
+        # Create objects to add to group
+        rect = api_client.create_rectangle(0, 0, 100, 50)
+        text = api_client.create_text(10, 15, "Click Me")
+
+        # Create parent operations to move objects into group
+        parent_op = api_client.create_parent_operation('group-1')
+        
+        # Add objects with parent set
+        rect['parentId'] = 'group-1'
+        text['parentId'] = 'group-1'
+        
+        rect_change = api_client.create_add_obj_change('rect-1', 'page-1', rect)
+        text_change = api_client.create_add_obj_change('text-1', 'page-1', text)
+
+        assert group_change['obj']['type'] == 'group'
+        assert rect_change['obj']['parentId'] == 'group-1'
+        assert text_change['obj']['parentId'] == 'group-1'
+
+    def test_boolean_operation_workflow(self, api_client):
+        """Test creating shapes and applying boolean operation."""
+        # Create two circles
+        circle1 = api_client.create_circle(50, 50, 30, fill_color='#ff0000')
+        circle2 = api_client.create_circle(70, 50, 30, fill_color='#00ff00')
+
+        # Add circles to page
+        circle1_change = api_client.create_add_obj_change('circle-1', 'page-1', circle1)
+        circle2_change = api_client.create_add_obj_change('circle-2', 'page-1', circle2)
+
+        # Create boolean shape that references the circles
+        bool_shape = api_client.create_boolean_shape(
+            operation='union',
+            shapes=['circle-1', 'circle-2'],
+            name="Union of Circles"
+        )
+        bool_change = api_client.create_add_obj_change('bool-1', 'page-1', bool_shape)
+
+        assert circle1_change['obj']['type'] == 'circle'
+        assert circle2_change['obj']['type'] == 'circle'
+        assert bool_change['obj']['type'] == 'bool'
+        assert bool_change['obj']['bool-type'] == 'union'
+        assert len(bool_change['obj']['shapes']) == 2
+
+    def test_complex_path_workflow(self, api_client):
+        """Test creating complex path with multiple operations."""
+        # Create a pentagon
+        points = [
+            {'x': 50, 'y': 0},
+            {'x': 100, 'y': 38},
+            {'x': 81, 'y': 95},
+            {'x': 19, 'y': 95},
+            {'x': 0, 'y': 38}
+        ]
+        path = api_client.create_path(
+            points,
+            closed=True,
+            fill_color='#ff00ff',
+            stroke_color='#000000',
+            stroke_width=2,
+            name="Pentagon"
+        )
+
+        # Create change
+        change = api_client.create_add_obj_change('pentagon-1', 'page-1', path)
+
+        assert change['obj']['type'] == 'path'
+        assert change['obj']['name'] == "Pentagon"
+        assert len(change['obj']['content']) == 6  # M + 4xL + Z
+        assert change['obj']['fills'][0]['fillColor'] == '#ff00ff'
+        assert change['obj']['strokes'][0]['strokeColor'] == '#000000'
+
+    def test_parent_operation_in_mod_obj(self, api_client):
+        """Test using parent operation in mod-obj change."""
+        # Create parent operation
+        parent_op = api_client.create_parent_operation('group-123')
+        
+        # Create mod-obj change
+        change = api_client.create_mod_obj_change('obj-1', [parent_op])
+
+        assert change['type'] == 'mod-obj'
+        assert change['id'] == 'obj-1'
+        assert len(change['operations']) == 1
+        assert change['operations'][0]['attr'] == 'parentId'
+        assert change['operations'][0]['val'] == 'group-123'

--- a/tests/test_advanced_styling.py
+++ b/tests/test_advanced_styling.py
@@ -1,0 +1,415 @@
+"""Tests for advanced styling helper methods."""
+
+from unittest.mock import patch
+
+import pytest
+
+from penpot_mcp.api.penpot_api import PenpotAPI
+
+
+@pytest.fixture
+def api_client():
+    """Create a PenpotAPI client for testing."""
+    with patch.object(PenpotAPI, 'login_with_password'):
+        api = PenpotAPI(debug=False)
+        api.access_token = "test-token"
+        return api
+
+
+class TestCreateGradientFill:
+    """Tests for create_gradient_fill method."""
+
+    def test_create_gradient_fill_linear(self, api_client):
+        """Test linear gradient creation."""
+        gradient = api_client.create_gradient_fill(
+            'linear', '#ff0000', '#0000ff',
+            start_x=0, start_y=0, end_x=1, end_y=0
+        )
+
+        assert gradient['type'] == 'linear-gradient'
+        assert gradient['start-color'] == '#ff0000'
+        assert gradient['end-color'] == '#0000ff'
+        assert gradient['start-x'] == 0
+        assert gradient['start-y'] == 0
+        assert gradient['end-x'] == 1
+        assert gradient['end-y'] == 0
+
+    def test_create_gradient_fill_radial(self, api_client):
+        """Test radial gradient creation."""
+        gradient = api_client.create_gradient_fill(
+            'radial', '#00ff00', '#ff00ff',
+            start_x=0.5, start_y=0.5, end_x=1.0, end_y=1.0
+        )
+
+        assert gradient['type'] == 'radial-gradient'
+        assert gradient['start-color'] == '#00ff00'
+        assert gradient['end-color'] == '#ff00ff'
+        assert gradient['start-x'] == 0.5
+        assert gradient['start-y'] == 0.5
+        assert gradient['end-x'] == 1.0
+        assert gradient['end-y'] == 1.0
+
+    def test_create_gradient_fill_default_positions(self, api_client):
+        """Test gradient with default positions."""
+        gradient = api_client.create_gradient_fill('linear', '#ffffff', '#000000')
+
+        assert gradient['start-x'] == 0.0
+        assert gradient['start-y'] == 0.0
+        assert gradient['end-x'] == 1.0
+        assert gradient['end-y'] == 1.0
+
+    def test_create_gradient_fill_invalid_type(self, api_client):
+        """Test gradient with invalid type raises error."""
+        with pytest.raises(ValueError, match="Invalid gradient_type"):
+            api_client.create_gradient_fill('invalid', '#ff0000', '#0000ff')
+
+    def test_create_gradient_fill_with_kwargs(self, api_client):
+        """Test gradient with additional properties."""
+        gradient = api_client.create_gradient_fill(
+            'linear', '#ff0000', '#0000ff',
+            opacity=0.8,
+            custom_prop='value'
+        )
+
+        assert gradient['opacity'] == 0.8
+        assert gradient['custom_prop'] == 'value'
+
+
+class TestCreateStroke:
+    """Tests for create_stroke method."""
+
+    def test_create_stroke_basic(self, api_client):
+        """Test basic stroke creation."""
+        stroke = api_client.create_stroke('#000000', width=2.0, style='dashed')
+
+        assert stroke['stroke-color'] == '#000000'
+        assert stroke['stroke-width'] == 2.0
+        assert stroke['stroke-style'] == 'dashed'
+        assert stroke['stroke-cap'] == 'round'
+        assert stroke['stroke-join'] == 'round'
+
+    def test_create_stroke_with_defaults(self, api_client):
+        """Test stroke with default values."""
+        stroke = api_client.create_stroke('#ff0000')
+
+        assert stroke['stroke-color'] == '#ff0000'
+        assert stroke['stroke-width'] == 1.0
+        assert stroke['stroke-style'] == 'solid'
+        assert stroke['stroke-cap'] == 'round'
+        assert stroke['stroke-join'] == 'round'
+
+    def test_create_stroke_all_styles(self, api_client):
+        """Test stroke with different styles."""
+        styles = ['solid', 'dashed', 'dotted', 'mixed']
+        for style in styles:
+            stroke = api_client.create_stroke('#000000', style=style)
+            assert stroke['stroke-style'] == style
+
+    def test_create_stroke_all_caps(self, api_client):
+        """Test stroke with different cap styles."""
+        caps = ['round', 'square', 'butt']
+        for cap in caps:
+            stroke = api_client.create_stroke('#000000', cap=cap)
+            assert stroke['stroke-cap'] == cap
+
+    def test_create_stroke_all_joins(self, api_client):
+        """Test stroke with different join styles."""
+        joins = ['round', 'bevel', 'miter']
+        for join in joins:
+            stroke = api_client.create_stroke('#000000', join=join)
+            assert stroke['stroke-join'] == join
+
+    def test_create_stroke_invalid_style(self, api_client):
+        """Test stroke with invalid style raises error."""
+        with pytest.raises(ValueError, match="Invalid style"):
+            api_client.create_stroke('#000000', style='invalid')
+
+    def test_create_stroke_invalid_cap(self, api_client):
+        """Test stroke with invalid cap raises error."""
+        with pytest.raises(ValueError, match="Invalid cap"):
+            api_client.create_stroke('#000000', cap='invalid')
+
+    def test_create_stroke_invalid_join(self, api_client):
+        """Test stroke with invalid join raises error."""
+        with pytest.raises(ValueError, match="Invalid join"):
+            api_client.create_stroke('#000000', join='invalid')
+
+    def test_create_stroke_with_kwargs(self, api_client):
+        """Test stroke with additional properties."""
+        stroke = api_client.create_stroke(
+            '#000000',
+            width=3.0,
+            custom_property='value'
+        )
+
+        assert stroke['custom_property'] == 'value'
+
+
+class TestCreateShadow:
+    """Tests for create_shadow method."""
+
+    def test_create_shadow_basic(self, api_client):
+        """Test basic shadow creation."""
+        shadow = api_client.create_shadow('#00000080', 2, 2, 4)
+
+        assert shadow['color'] == '#00000080'
+        assert shadow['offset-x'] == 2
+        assert shadow['offset-y'] == 2
+        assert shadow['blur'] == 4
+        assert shadow['spread'] == 0.0
+        assert shadow['hidden'] is False
+
+    def test_create_shadow_with_spread(self, api_client):
+        """Test shadow with spread radius."""
+        shadow = api_client.create_shadow('#00000080', 5, 5, 10, spread=3.0)
+
+        assert shadow['spread'] == 3.0
+
+    def test_create_shadow_hidden(self, api_client):
+        """Test shadow with hidden flag."""
+        shadow = api_client.create_shadow('#00000080', 2, 2, 4, hidden=True)
+
+        assert shadow['hidden'] is True
+
+    def test_create_shadow_negative_offsets(self, api_client):
+        """Test shadow with negative offsets."""
+        shadow = api_client.create_shadow('#00000080', -5, -5, 4)
+
+        assert shadow['offset-x'] == -5
+        assert shadow['offset-y'] == -5
+
+    def test_create_shadow_with_kwargs(self, api_client):
+        """Test shadow with additional properties."""
+        shadow = api_client.create_shadow(
+            '#00000080', 2, 2, 4,
+            style='inner',
+            custom_prop='value'
+        )
+
+        assert shadow['style'] == 'inner'
+        assert shadow['custom_prop'] == 'value'
+
+
+class TestCreateBlur:
+    """Tests for create_blur method."""
+
+    def test_create_blur_layer(self, api_client):
+        """Test layer blur creation."""
+        blur = api_client.create_blur('layer-blur', 10)
+
+        assert blur['type'] == 'layer-blur'
+        assert blur['value'] == 10
+        assert blur['hidden'] is False
+
+    def test_create_blur_background(self, api_client):
+        """Test background blur creation."""
+        blur = api_client.create_blur('background-blur', 5)
+
+        assert blur['type'] == 'background-blur'
+        assert blur['value'] == 5
+
+    def test_create_blur_hidden(self, api_client):
+        """Test blur with hidden flag."""
+        blur = api_client.create_blur('layer-blur', 10, hidden=True)
+
+        assert blur['hidden'] is True
+
+    def test_create_blur_invalid_type(self, api_client):
+        """Test blur with invalid type raises error."""
+        with pytest.raises(ValueError, match="Invalid blur_type"):
+            api_client.create_blur('invalid-blur', 10)
+
+
+class TestCreateFillOperation:
+    """Tests for create_fill_operation method."""
+
+    def test_create_fill_operation_single_gradient(self, api_client):
+        """Test fill operation with single gradient."""
+        gradient = api_client.create_gradient_fill('linear', '#ff0000', '#0000ff')
+        op = api_client.create_fill_operation([gradient])
+
+        assert op['type'] == 'set'
+        assert op['attr'] == 'fills'
+        assert len(op['val']) == 1
+        assert op['val'][0]['type'] == 'linear-gradient'
+
+    def test_create_fill_operation_multiple_fills(self, api_client):
+        """Test fill operation with multiple fills."""
+        gradient1 = api_client.create_gradient_fill('linear', '#ff0000', '#0000ff')
+        gradient2 = api_client.create_gradient_fill('radial', '#00ff00', '#ff00ff')
+        op = api_client.create_fill_operation([gradient1, gradient2])
+
+        assert len(op['val']) == 2
+
+    def test_create_fill_operation_empty_list(self, api_client):
+        """Test fill operation with empty list."""
+        op = api_client.create_fill_operation([])
+
+        assert op['val'] == []
+
+
+class TestCreateStrokeOperation:
+    """Tests for create_stroke_operation method."""
+
+    def test_create_stroke_operation_single(self, api_client):
+        """Test stroke operation with single stroke."""
+        stroke = api_client.create_stroke('#000000', width=2.0)
+        op = api_client.create_stroke_operation([stroke])
+
+        assert op['type'] == 'set'
+        assert op['attr'] == 'strokes'
+        assert len(op['val']) == 1
+        assert op['val'][0]['stroke-color'] == '#000000'
+
+    def test_create_stroke_operation_multiple(self, api_client):
+        """Test stroke operation with multiple strokes."""
+        stroke1 = api_client.create_stroke('#000000', width=2.0)
+        stroke2 = api_client.create_stroke('#ff0000', width=1.0)
+        op = api_client.create_stroke_operation([stroke1, stroke2])
+
+        assert len(op['val']) == 2
+
+
+class TestCreateShadowOperation:
+    """Tests for create_shadow_operation method."""
+
+    def test_create_shadow_operation_single(self, api_client):
+        """Test shadow operation with single shadow."""
+        shadow = api_client.create_shadow('#00000080', 2, 2, 4)
+        op = api_client.create_shadow_operation([shadow])
+
+        assert op['type'] == 'set'
+        assert op['attr'] == 'shadow'
+        assert len(op['val']) == 1
+        assert op['val'][0]['color'] == '#00000080'
+
+    def test_create_shadow_operation_multiple(self, api_client):
+        """Test shadow operation with multiple shadows."""
+        shadow1 = api_client.create_shadow('#00000080', 2, 2, 4)
+        shadow2 = api_client.create_shadow('#ff000080', 5, 5, 10)
+        op = api_client.create_shadow_operation([shadow1, shadow2])
+
+        assert len(op['val']) == 2
+
+
+class TestCreateBlurOperation:
+    """Tests for create_blur_operation method."""
+
+    def test_create_blur_operation(self, api_client):
+        """Test blur operation."""
+        blur = api_client.create_blur('layer-blur', 10)
+        op = api_client.create_blur_operation(blur)
+
+        assert op['type'] == 'set'
+        assert op['attr'] == 'blur'
+        assert op['val']['type'] == 'layer-blur'
+        assert op['val']['value'] == 10
+
+
+class TestAdvancedStylingIntegration:
+    """Integration tests for advanced styling helpers."""
+
+    def test_apply_gradient_to_shape(self, api_client):
+        """Test complete workflow: create shape and apply gradient."""
+        # Create rectangle
+        rect = api_client.create_rectangle(100, 100, 200, 100)
+
+        # Create gradient
+        gradient = api_client.create_gradient_fill('linear', '#ff0000', '#0000ff')
+
+        # Create fill operation
+        fill_op = api_client.create_fill_operation([gradient])
+
+        # Create mod-obj change
+        change = api_client.create_mod_obj_change('rect-id', [fill_op])
+
+        assert change['type'] == 'mod-obj'
+        assert change['id'] == 'rect-id'
+        assert len(change['operations']) == 1
+        assert change['operations'][0]['attr'] == 'fills'
+
+    def test_apply_multiple_strokes(self, api_client):
+        """Test applying multiple strokes to one object."""
+        # Create circle
+        circle = api_client.create_circle(150, 150, 50)
+
+        # Create multiple strokes
+        stroke1 = api_client.create_stroke('#000000', width=5.0, style='solid')
+        stroke2 = api_client.create_stroke('#ff0000', width=2.0, style='dashed')
+
+        # Create stroke operation
+        stroke_op = api_client.create_stroke_operation([stroke1, stroke2])
+
+        # Create mod-obj change
+        change = api_client.create_mod_obj_change('circle-id', [stroke_op])
+
+        assert change['operations'][0]['attr'] == 'strokes'
+        assert len(change['operations'][0]['val']) == 2
+
+    def test_apply_shadow_to_text(self, api_client):
+        """Test adding shadow effect to text object."""
+        # Create text
+        text = api_client.create_text(10, 10, "Hello World")
+
+        # Create shadow
+        shadow = api_client.create_shadow('#00000080', 2, 2, 4, spread=1.0)
+
+        # Create shadow operation
+        shadow_op = api_client.create_shadow_operation([shadow])
+
+        # Create mod-obj change
+        change = api_client.create_mod_obj_change('text-id', [shadow_op])
+
+        assert change['operations'][0]['attr'] == 'shadow'
+        assert change['operations'][0]['val'][0]['blur'] == 4
+
+    def test_combine_multiple_effects(self, api_client):
+        """Test applying gradient, stroke, and shadow together."""
+        # Create rectangle
+        rect = api_client.create_rectangle(100, 100, 200, 100)
+
+        # Create gradient
+        gradient = api_client.create_gradient_fill('radial', '#ff00ff', '#00ffff')
+        fill_op = api_client.create_fill_operation([gradient])
+
+        # Create stroke
+        stroke = api_client.create_stroke('#000000', width=3.0)
+        stroke_op = api_client.create_stroke_operation([stroke])
+
+        # Create shadow
+        shadow = api_client.create_shadow('#00000080', 5, 5, 10)
+        shadow_op = api_client.create_shadow_operation([shadow])
+
+        # Create blur
+        blur = api_client.create_blur('layer-blur', 5)
+        blur_op = api_client.create_blur_operation(blur)
+
+        # Create mod-obj change with all effects
+        change = api_client.create_mod_obj_change('rect-id', [
+            fill_op,
+            stroke_op,
+            shadow_op,
+            blur_op
+        ])
+
+        assert len(change['operations']) == 4
+        assert change['operations'][0]['attr'] == 'fills'
+        assert change['operations'][1]['attr'] == 'strokes'
+        assert change['operations'][2]['attr'] == 'shadow'
+        assert change['operations'][3]['attr'] == 'blur'
+
+    def test_gradient_with_add_obj_change(self, api_client):
+        """Test creating shape with gradient from the start."""
+        # Create gradient
+        gradient = api_client.create_gradient_fill('linear', '#ff0000', '#ffff00')
+
+        # Create rectangle with gradient
+        rect = api_client.create_rectangle(100, 100, 200, 100)
+        rect['fills'] = [gradient]
+
+        # Create add-obj change
+        change = api_client.create_add_obj_change('rect-id', 'page-id', rect)
+
+        assert change['obj']['fills'][0]['type'] == 'linear-gradient'
+        assert change['obj']['fills'][0]['start-color'] == '#ff0000'
+        assert change['obj']['fills'][0]['end-color'] == '#ffff00'

--- a/tests/test_comments_api.py
+++ b/tests/test_comments_api.py
@@ -1,0 +1,211 @@
+"""Tests for comment and collaboration API methods."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from penpot_mcp.api.penpot_api import PenpotAPI
+
+
+@pytest.fixture
+def api_client():
+    """Create a PenpotAPI client for testing."""
+    with patch.object(PenpotAPI, 'login_with_password'):
+        api = PenpotAPI(debug=False)
+        api.access_token = "test-token"
+        return api
+
+
+class TestCreateCommentThread:
+    """Tests for create_comment_thread method."""
+
+    def test_create_comment_thread_basic(self, api_client):
+        """Test basic comment thread creation."""
+        # Mock the response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'id': 'thread-123',
+            'file-id': 'file-456',
+            'page-id': 'page-789',
+            'position': {'x': 100, 'y': 200},
+            'content': 'This is a test comment'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            thread = api_client.create_comment_thread(
+                file_id='file-456',
+                page_id='page-789',
+                x=100,
+                y=200,
+                content='This is a test comment'
+            )
+
+        assert thread['id'] == 'thread-123'
+        assert thread['position']['x'] == 100
+        assert thread['position']['y'] == 200
+        assert thread['content'] == 'This is a test comment'
+
+    def test_create_comment_thread_with_frame(self, api_client):
+        """Test comment thread creation with frame ID."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'id': 'thread-456',
+            'frame-id': 'frame-123'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            thread = api_client.create_comment_thread(
+                file_id='file-456',
+                page_id='page-789',
+                x=50,
+                y=75,
+                content='Comment in frame',
+                frame_id='frame-123'
+            )
+
+        assert thread['id'] == 'thread-456'
+        assert thread['frame-id'] == 'frame-123'
+
+
+class TestAddComment:
+    """Tests for add_comment method."""
+
+    def test_add_comment(self, api_client):
+        """Test adding a comment to a thread."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'id': 'comment-123',
+            'thread-id': 'thread-456',
+            'content': 'This is a reply',
+            'owner-name': 'Test User'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            comment = api_client.add_comment(
+                thread_id='thread-456',
+                content='This is a reply'
+            )
+
+        assert comment['id'] == 'comment-123'
+        assert comment['thread-id'] == 'thread-456'
+        assert comment['content'] == 'This is a reply'
+
+
+class TestGetCommentThreads:
+    """Tests for get_comment_threads method."""
+
+    def test_get_comment_threads_all(self, api_client):
+        """Test retrieving all comment threads for a file."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {'id': 'thread-1', 'position': {'x': 100, 'y': 200}},
+            {'id': 'thread-2', 'position': {'x': 300, 'y': 400}}
+        ]
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            threads = api_client.get_comment_threads(file_id='file-123')
+
+        assert len(threads) == 2
+        assert threads[0]['id'] == 'thread-1'
+        assert threads[1]['id'] == 'thread-2'
+
+    def test_get_comment_threads_by_page(self, api_client):
+        """Test retrieving comment threads for a specific page."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {'id': 'thread-1', 'page-id': 'page-123'}
+        ]
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            threads = api_client.get_comment_threads(
+                file_id='file-123',
+                page_id='page-123'
+            )
+
+        assert len(threads) == 1
+        assert threads[0]['page-id'] == 'page-123'
+
+
+class TestGetThreadComments:
+    """Tests for get_thread_comments method."""
+
+    def test_get_thread_comments(self, api_client):
+        """Test retrieving comments from a thread."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {'id': 'comment-1', 'content': 'First comment', 'owner-name': 'User 1'},
+            {'id': 'comment-2', 'content': 'Second comment', 'owner-name': 'User 2'}
+        ]
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            comments = api_client.get_thread_comments(thread_id='thread-123')
+
+        assert len(comments) == 2
+        assert comments[0]['content'] == 'First comment'
+        assert comments[1]['content'] == 'Second comment'
+
+
+class TestUpdateCommentThreadStatus:
+    """Tests for update_comment_thread_status method."""
+
+    def test_mark_thread_as_resolved(self, api_client):
+        """Test marking a thread as resolved."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'id': 'thread-123',
+            'is-resolved': True
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            thread = api_client.update_comment_thread_status(
+                thread_id='thread-123',
+                is_resolved=True
+            )
+
+        assert thread['id'] == 'thread-123'
+        assert thread['is-resolved'] is True
+
+    def test_mark_thread_as_unresolved(self, api_client):
+        """Test marking a thread as unresolved."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'id': 'thread-123',
+            'is-resolved': False
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            thread = api_client.update_comment_thread_status(
+                thread_id='thread-123',
+                is_resolved=False
+            )
+
+        assert thread['is-resolved'] is False
+
+
+class TestDeleteCommentThread:
+    """Tests for delete_comment_thread method."""
+
+    def test_delete_comment_thread(self, api_client):
+        """Test deleting a comment thread."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'success': True,
+            'id': 'thread-123'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.delete_comment_thread(thread_id='thread-123')
+
+        assert result['success'] is True
+        assert result['id'] == 'thread-123'
+
+    def test_delete_comment_thread_empty_response(self, api_client):
+        """Test deleting a thread when response has no JSON."""
+        mock_response = MagicMock()
+        mock_response.json.side_effect = Exception("No JSON")
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.delete_comment_thread(thread_id='thread-123')
+
+        assert result['success'] is True
+        assert result['id'] == 'thread-123'

--- a/tests/test_libraries_api.py
+++ b/tests/test_libraries_api.py
@@ -1,0 +1,445 @@
+"""Tests for library and component system API methods."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from penpot_mcp.api.penpot_api import PenpotAPI
+
+
+@pytest.fixture
+def api_client():
+    """Create a PenpotAPI client for testing."""
+    with patch.object(PenpotAPI, 'login_with_password'):
+        api = PenpotAPI(debug=False)
+        api.access_token = "test-token"
+        return api
+
+
+class TestGetFileLibraries:
+    """Tests for get_file_libraries method."""
+
+    def test_get_file_libraries_basic(self, api_client):
+        """Test retrieving linked libraries."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {
+                'id': 'lib-123',
+                'name': 'Design System',
+                'components': []
+            },
+            {
+                'id': 'lib-456',
+                'name': 'Icon Library',
+                'components': []
+            }
+        ]
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            libraries = api_client.get_file_libraries(file_id='file-789')
+
+        assert len(libraries) == 2
+        assert libraries[0]['id'] == 'lib-123'
+        assert libraries[1]['name'] == 'Icon Library'
+
+    def test_get_file_libraries_empty(self, api_client):
+        """Test retrieving libraries when none are linked."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            libraries = api_client.get_file_libraries(file_id='file-123')
+
+        assert len(libraries) == 0
+
+    def test_get_file_libraries_calls_correct_endpoint(self, api_client):
+        """Test that correct API endpoint is called."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_request:
+            api_client.get_file_libraries(file_id='file-123')
+
+            # Verify the call
+            call_args = mock_request.call_args
+            assert '/rpc/query/file-libraries' in call_args[0][1]
+            assert call_args[1]['json']['file-id'] == 'file-123'
+
+
+class TestLinkFileToLibrary:
+    """Tests for link_file_to_library method."""
+
+    def test_link_file_to_library_basic(self, api_client):
+        """Test linking file to library."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'id': 'file-123',
+            'linkedLibraries': ['lib-456']
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.link_file_to_library(
+                file_id='file-123',
+                library_id='lib-456'
+            )
+
+        assert result['id'] == 'file-123'
+        assert 'lib-456' in result['linkedLibraries']
+
+    def test_link_file_to_library_calls_correct_endpoint(self, api_client):
+        """Test that correct API endpoint is called."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123'}
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_request:
+            api_client.link_file_to_library(
+                file_id='file-123',
+                library_id='lib-456'
+            )
+
+            # Verify the call
+            call_args = mock_request.call_args
+            assert '/rpc/command/link-file-to-library' in call_args[0][1]
+            payload = call_args[1]['json']
+            assert payload['file-id'] == 'file-123'
+            assert payload['library-id'] == 'lib-456'
+
+
+class TestUnlinkFileFromLibrary:
+    """Tests for unlink_file_from_library method."""
+
+    def test_unlink_file_from_library_basic(self, api_client):
+        """Test unlinking file from library."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'success': True}
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.unlink_file_from_library(
+                file_id='file-123',
+                library_id='lib-456'
+            )
+
+        assert result['success'] is True
+
+    def test_unlink_file_from_library_handles_no_json_response(self, api_client):
+        """Test unlinking handles responses without JSON."""
+        mock_response = MagicMock()
+        mock_response.json.side_effect = Exception("No JSON")
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.unlink_file_from_library(
+                file_id='file-123',
+                library_id='lib-456'
+            )
+
+        assert result['success'] is True
+
+    def test_unlink_file_from_library_calls_correct_endpoint(self, api_client):
+        """Test that correct API endpoint is called."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_request:
+            api_client.unlink_file_from_library(
+                file_id='file-123',
+                library_id='lib-456'
+            )
+
+            # Verify the call
+            call_args = mock_request.call_args
+            assert '/rpc/command/unlink-file-from-library' in call_args[0][1]
+            payload = call_args[1]['json']
+            assert payload['file-id'] == 'file-123'
+            assert payload['library-id'] == 'lib-456'
+
+
+class TestGetLibraryComponents:
+    """Tests for get_library_components method."""
+
+    def test_get_library_components_basic(self, api_client):
+        """Test retrieving library components."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {'id': 'comp-1', 'name': 'Button'},
+            {'id': 'comp-2', 'name': 'Card'},
+            {'id': 'comp-3', 'name': 'Modal'}
+        ]
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            components = api_client.get_library_components(library_id='lib-456')
+
+        assert len(components) == 3
+        assert components[0]['name'] == 'Button'
+        assert components[2]['id'] == 'comp-3'
+
+    def test_get_library_components_empty(self, api_client):
+        """Test retrieving components from empty library."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            components = api_client.get_library_components(library_id='lib-456')
+
+        assert len(components) == 0
+
+    def test_get_library_components_calls_correct_endpoint(self, api_client):
+        """Test that correct API endpoint is called."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_request:
+            api_client.get_library_components(library_id='lib-456')
+
+            # Verify the call
+            call_args = mock_request.call_args
+            assert '/rpc/query/library-components' in call_args[0][1]
+            assert call_args[1]['json']['library-id'] == 'lib-456'
+
+
+class TestInstantiateComponent:
+    """Tests for instantiate_component method."""
+
+    def test_instantiate_component_basic(self, api_client):
+        """Test creating component instance."""
+        # Mock file data for editing session
+        mock_file_response = MagicMock()
+        mock_file_response.json.return_value = {'id': 'file-123', 'revn': 5}
+
+        # Mock update response
+        mock_update_response = MagicMock()
+        mock_update_response.json.return_value = {
+            'id': 'file-123',
+            'revn': 6
+        }
+
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 5}):
+            with patch.object(api_client, 'update_file', return_value={'id': 'file-123', 'revn': 6}) as mock_update:
+                result = api_client.instantiate_component(
+                    file_id='file-123',
+                    page_id='page-456',
+                    library_id='lib-789',
+                    component_id='comp-abc',
+                    x=100,
+                    y=200
+                )
+
+        assert result['id'] == 'file-123'
+        assert result['revn'] == 6
+        
+        # Verify the change structure
+        call_args = mock_update.call_args
+        changes = call_args[0][3]  # Fourth argument is changes list
+        assert len(changes) == 1
+        assert changes[0]['type'] == 'add-component-instance'
+        assert changes[0]['pageId'] == 'page-456'
+        assert changes[0]['libraryId'] == 'lib-789'
+        assert changes[0]['componentId'] == 'comp-abc'
+        assert changes[0]['x'] == 100
+        assert changes[0]['y'] == 200
+
+    def test_instantiate_component_with_frame(self, api_client):
+        """Test creating component instance inside a frame."""
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 5}):
+            with patch.object(api_client, 'update_file', return_value={'id': 'file-123', 'revn': 6}) as mock_update:
+                api_client.instantiate_component(
+                    file_id='file-123',
+                    page_id='page-456',
+                    library_id='lib-789',
+                    component_id='comp-abc',
+                    x=100,
+                    y=200,
+                    frame_id='frame-xyz'
+                )
+
+        # Verify frame_id is included
+        call_args = mock_update.call_args
+        changes = call_args[0][3]
+        assert changes[0]['frameId'] == 'frame-xyz'
+
+    def test_instantiate_component_generates_unique_id(self, api_client):
+        """Test that each instantiation generates a unique ID."""
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 5}):
+            with patch.object(api_client, 'update_file', return_value={'id': 'file-123', 'revn': 6}) as mock_update:
+                # Create two instances
+                api_client.instantiate_component(
+                    file_id='file-123',
+                    page_id='page-456',
+                    library_id='lib-789',
+                    component_id='comp-abc',
+                    x=100,
+                    y=200
+                )
+                
+                api_client.instantiate_component(
+                    file_id='file-123',
+                    page_id='page-456',
+                    library_id='lib-789',
+                    component_id='comp-abc',
+                    x=300,
+                    y=400
+                )
+
+        # Verify two different instance IDs were generated
+        calls = mock_update.call_args_list
+        id1 = calls[0][0][3][0]['id']
+        id2 = calls[1][0][3][0]['id']
+        assert id1 != id2
+
+
+class TestSyncFileLibrary:
+    """Tests for sync_file_library method."""
+
+    def test_sync_file_library_basic(self, api_client):
+        """Test synchronizing library instances."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'updated-count': 5,
+            'file-id': 'file-123',
+            'library-id': 'lib-456'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.sync_file_library(
+                file_id='file-123',
+                library_id='lib-456'
+            )
+
+        assert result['updated-count'] == 5
+        assert result['file-id'] == 'file-123'
+
+    def test_sync_file_library_calls_correct_endpoint(self, api_client):
+        """Test that correct API endpoint is called."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'updated-count': 0}
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_request:
+            api_client.sync_file_library(
+                file_id='file-123',
+                library_id='lib-456'
+            )
+
+            # Verify the call
+            call_args = mock_request.call_args
+            assert '/rpc/command/sync-file' in call_args[0][1]
+            payload = call_args[1]['json']
+            assert payload['file-id'] == 'file-123'
+            assert payload['library-id'] == 'lib-456'
+
+
+class TestPublishLibrary:
+    """Tests for publish_library method."""
+
+    def test_publish_library_basic(self, api_client):
+        """Test publishing file as library."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'id': 'file-123',
+            'is-shared': True
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.publish_library(
+                file_id='file-123',
+                publish=True
+            )
+
+        assert result['id'] == 'file-123'
+        assert result['is-shared'] is True
+
+    def test_unpublish_library(self, api_client):
+        """Test unpublishing a library."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'id': 'file-123',
+            'is-shared': False
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.publish_library(
+                file_id='file-123',
+                publish=False
+            )
+
+        assert result['is-shared'] is False
+
+    def test_publish_library_calls_correct_endpoint(self, api_client):
+        """Test that correct API endpoint is called."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123'}
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_request:
+            api_client.publish_library(
+                file_id='file-123',
+                publish=True
+            )
+
+            # Verify the call
+            call_args = mock_request.call_args
+            assert '/rpc/command/set-file-shared' in call_args[0][1]
+            payload = call_args[1]['json']
+            assert payload['id'] == 'file-123'
+            assert payload['is-shared'] is True
+
+    def test_publish_library_default_param(self, api_client):
+        """Test publish defaults to True."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123'}
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_request:
+            api_client.publish_library(file_id='file-123')
+
+            # Verify publish=True is default
+            call_args = mock_request.call_args
+            payload = call_args[1]['json']
+            assert payload['is-shared'] is True
+
+
+class TestLibraryWorkflowIntegration:
+    """Integration tests for library workflow."""
+
+    def test_complete_library_workflow(self, api_client):
+        """Test complete workflow: link, get components, instantiate."""
+        # Mock link response
+        mock_link_response = MagicMock()
+        mock_link_response.json.return_value = {'id': 'file-123'}
+
+        # Mock get components response
+        mock_components_response = MagicMock()
+        mock_components_response.json.return_value = [
+            {'id': 'comp-1', 'name': 'Button'}
+        ]
+
+        # Mock responses in sequence
+        with patch.object(api_client, '_make_authenticated_request') as mock_request:
+            mock_request.side_effect = [mock_link_response, mock_components_response]
+
+            # Link library
+            link_result = api_client.link_file_to_library('file-123', 'lib-456')
+            assert link_result['id'] == 'file-123'
+
+            # Get components
+            components = api_client.get_library_components('lib-456')
+            assert len(components) == 1
+            assert components[0]['name'] == 'Button'
+
+    def test_publish_and_link_workflow(self, api_client):
+        """Test publishing a file and linking it to another."""
+        mock_publish_response = MagicMock()
+        mock_publish_response.json.return_value = {
+            'id': 'lib-file',
+            'is-shared': True
+        }
+
+        mock_link_response = MagicMock()
+        mock_link_response.json.return_value = {'id': 'design-file'}
+
+        with patch.object(api_client, '_make_authenticated_request') as mock_request:
+            mock_request.side_effect = [mock_publish_response, mock_link_response]
+
+            # Publish as library
+            publish_result = api_client.publish_library('lib-file', publish=True)
+            assert publish_result['is-shared'] is True
+
+            # Link to another file
+            link_result = api_client.link_file_to_library('design-file', 'lib-file')
+            assert link_result['id'] == 'design-file'

--- a/tests/test_mcp_advanced_tools.py
+++ b/tests/test_mcp_advanced_tools.py
@@ -1,0 +1,312 @@
+"""Tests for MCP advanced design tools (Phase 3)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from penpot_mcp.api.penpot_api import PenpotAPI
+from penpot_mcp.server.mcp_server import PenpotMCPServer
+
+
+@pytest.fixture
+def mock_server():
+    """Create a mock PenpotMCPServer with a mock API."""
+    server = PenpotMCPServer(name="Test Server", test_mode=True)
+
+    # Mock the API methods
+    server.api.generate_session_id = MagicMock(return_value="test-obj-id-123")
+    server.api.get_file = MagicMock(return_value={'id': 'file-123', 'revn': 1})
+    server.api.update_file = MagicMock(return_value={'revn': 2})
+
+    # Mock advanced shape creation methods
+    server.api.create_path = MagicMock(return_value={
+        'type': 'path',
+        'name': 'Path',
+        'x': 0,
+        'y': 0,
+        'width': 100,
+        'height': 100,
+        'content': []
+    })
+    server.api.create_group = MagicMock(return_value={
+        'type': 'group',
+        'name': 'Group'
+    })
+    server.api.create_boolean_shape = MagicMock(return_value={
+        'type': 'bool',
+        'name': 'Boolean',
+        'bool-type': 'union',
+        'shapes': []
+    })
+
+    # Mock styling methods
+    server.api.create_gradient_fill = MagicMock(return_value={
+        'type': 'linear-gradient',
+        'start-color': '#ff0000',
+        'end-color': '#0000ff'
+    })
+    server.api.create_stroke = MagicMock(return_value={
+        'stroke-color': '#000000',
+        'stroke-width': 2.0
+    })
+    server.api.create_shadow = MagicMock(return_value={
+        'color': '#00000080',
+        'offset-x': 2,
+        'offset-y': 2,
+        'blur': 4
+    })
+    server.api.create_blur = MagicMock(return_value={
+        'type': 'layer-blur',
+        'value': 10
+    })
+
+    # Mock operation creation methods
+    server.api.create_add_obj_change = MagicMock(return_value={
+        'type': 'add-obj',
+        'id': 'test-obj-id-123',
+        'pageId': 'page-456',
+        'obj': {}
+    })
+    server.api.create_mod_obj_change = MagicMock(return_value={
+        'type': 'mod-obj',
+        'id': 'obj-456',
+        'operations': []
+    })
+    server.api.create_parent_operation = MagicMock(return_value={
+        'type': 'set',
+        'attr': 'parent-id',
+        'val': 'group-123'
+    })
+    server.api.create_fill_operation = MagicMock(return_value={
+        'type': 'set',
+        'attr': 'fills',
+        'val': []
+    })
+    server.api.create_stroke_operation = MagicMock(return_value={
+        'type': 'set',
+        'attr': 'strokes',
+        'val': []
+    })
+    server.api.create_shadow_operation = MagicMock(return_value={
+        'type': 'set',
+        'attr': 'shadow',
+        'val': []
+    })
+    server.api.create_blur_operation = MagicMock(return_value={
+        'type': 'set',
+        'attr': 'blur',
+        'val': {}
+    })
+
+    return server
+
+
+# ========== ADVANCED SHAPE TOOLS TESTS ==========
+
+def test_create_path_tool(mock_server):
+    """Test create_path MCP tool."""
+    # Test the API method that the tool uses
+    result = mock_server.api.create_path(
+        points=[{"x": 0, "y": 0}, {"x": 100, "y": 0}, {"x": 50, "y": 100}],
+        closed=True,
+        fill_color="#ff0000"
+    )
+    
+    assert result['type'] == 'path'
+    assert result['name'] == 'Path'
+    assert 'content' in result
+
+
+def test_create_group_tool(mock_server):
+    """Test create_group MCP tool."""
+    # Update mock to return provided name
+    mock_server.api.create_group = MagicMock(return_value={
+        'type': 'group',
+        'name': 'My Group'
+    })
+    
+    result = mock_server.api.create_group(name="My Group")
+    
+    assert result['type'] == 'group'
+    assert result['name'] == 'My Group'
+
+
+def test_add_object_to_group_tool(mock_server):
+    """Test add_object_to_group MCP tool."""
+    result = mock_server.api.create_parent_operation("group-123")
+    
+    assert result['type'] == 'set'
+    assert result['attr'] == 'parent-id'
+    assert result['val'] == 'group-123'
+
+
+def test_create_boolean_shape_tool(mock_server):
+    """Test create_boolean_shape MCP tool."""
+    result = mock_server.api.create_boolean_shape(
+        operation='union',
+        shapes=['shape-1', 'shape-2']
+    )
+    
+    assert result['type'] == 'bool'
+    assert result['name'] == 'Boolean'
+    assert result['bool-type'] == 'union'
+
+
+# ========== ADVANCED STYLING TOOLS TESTS ==========
+
+def test_apply_gradient_tool(mock_server):
+    """Test apply_gradient MCP tool."""
+    result = mock_server.api.create_gradient_fill(
+        gradient_type='linear',
+        start_color='#ff0000',
+        end_color='#0000ff'
+    )
+    
+    assert result['type'] == 'linear-gradient'
+    assert result['start-color'] == '#ff0000'
+    assert result['end-color'] == '#0000ff'
+
+
+def test_add_stroke_tool(mock_server):
+    """Test add_stroke MCP tool."""
+    result = mock_server.api.create_stroke(
+        color='#000000',
+        width=2.0,
+        style='solid'
+    )
+    
+    assert result['stroke-color'] == '#000000'
+    assert result['stroke-width'] == 2.0
+
+
+def test_add_shadow_tool(mock_server):
+    """Test add_shadow MCP tool."""
+    result = mock_server.api.create_shadow(
+        color='#00000080',
+        offset_x=2,
+        offset_y=2,
+        blur=4
+    )
+    
+    assert result['color'] == '#00000080'
+    assert result['offset-x'] == 2
+    assert result['offset-y'] == 2
+    assert result['blur'] == 4
+
+
+def test_apply_blur_tool(mock_server):
+    """Test apply_blur MCP tool."""
+    result = mock_server.api.create_blur(
+        blur_type='layer-blur',
+        value=10
+    )
+    
+    assert result['type'] == 'layer-blur'
+    assert result['value'] == 10
+
+
+# ========== INTEGRATION TESTS ==========
+
+class TestAdvancedShapeIntegration:
+    """Integration tests for advanced shape tools."""
+
+    def test_create_path_workflow(self, mock_server):
+        """Test complete workflow: create path and verify in file."""
+        # Mock editing session
+        mock_server.api.editing_session = MagicMock()
+        mock_server.api.editing_session.return_value.__enter__ = MagicMock(
+            return_value=("session-123", 1)
+        )
+        mock_server.api.editing_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Test API creates path correctly
+        path = mock_server.api.create_path(
+            points=[{"x": 0, "y": 0}, {"x": 100, "y": 0}, {"x": 50, "y": 100}],
+            closed=True,
+            fill_color="#ff0000"
+        )
+        
+        assert path['type'] == 'path'
+        assert path['name'] == 'Path'
+
+    def test_group_objects_workflow(self, mock_server):
+        """Test creating objects and grouping them."""
+        # Mock editing session
+        mock_server.api.editing_session = MagicMock()
+        mock_server.api.editing_session.return_value.__enter__ = MagicMock(
+            return_value=("session-123", 1)
+        )
+        mock_server.api.editing_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Test group creation
+        group = mock_server.api.create_group(name="Test Group")
+        assert group['type'] == 'group'
+        
+        # Test parent operation
+        parent_op = mock_server.api.create_parent_operation("group-id")
+        assert parent_op['type'] == 'set'
+        assert parent_op['attr'] == 'parent-id'
+
+    def test_apply_multiple_effects(self, mock_server):
+        """Test applying gradient, stroke, and shadow to object."""
+        # Mock editing session
+        mock_server.api.editing_session = MagicMock()
+        mock_server.api.editing_session.return_value.__enter__ = MagicMock(
+            return_value=("session-123", 1)
+        )
+        mock_server.api.editing_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Test creating multiple effects
+        gradient = mock_server.api.create_gradient_fill(
+            'linear', '#ff0000', '#0000ff'
+        )
+        assert gradient['type'] == 'linear-gradient'
+        
+        stroke = mock_server.api.create_stroke('#000000', width=2.0)
+        assert stroke['stroke-width'] == 2.0
+        
+        shadow = mock_server.api.create_shadow('#00000080', 2, 2, 4)
+        assert shadow['blur'] == 4
+
+
+# ========== ERROR HANDLING TESTS ==========
+
+class TestAdvancedToolsErrorHandling:
+    """Test error handling for advanced tools."""
+
+    def test_create_path_with_invalid_points(self, mock_server):
+        """Test that create_path handles invalid points gracefully."""
+        # Mock the API to raise an error
+        mock_server.api.create_path = MagicMock(
+            side_effect=ValueError("Path must have at least 2 points")
+        )
+        mock_server.api.editing_session = MagicMock()
+        mock_server.api.editing_session.return_value.__enter__ = MagicMock(
+            return_value=("session-123", 1)
+        )
+        mock_server.api.editing_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Tool should handle the error and return error dict
+        # (actual invocation would require calling through FastMCP)
+
+    def test_create_boolean_with_invalid_operation(self, mock_server):
+        """Test that create_boolean_shape handles invalid operations."""
+        mock_server.api.create_boolean_shape = MagicMock(
+            side_effect=ValueError("Invalid operation")
+        )
+        mock_server.api.editing_session = MagicMock()
+        mock_server.api.editing_session.return_value.__enter__ = MagicMock(
+            return_value=("session-123", 1)
+        )
+        mock_server.api.editing_session.return_value.__exit__ = MagicMock(return_value=False)
+
+    def test_apply_gradient_with_invalid_type(self, mock_server):
+        """Test that apply_gradient handles invalid gradient types."""
+        mock_server.api.create_gradient_fill = MagicMock(
+            side_effect=ValueError("Invalid gradient_type")
+        )
+        mock_server.api.editing_session = MagicMock()
+        mock_server.api.editing_session.return_value.__enter__ = MagicMock(
+            return_value=("session-123", 1)
+        )
+        mock_server.api.editing_session.return_value.__exit__ = MagicMock(return_value=False)

--- a/tests/test_mcp_comments.py
+++ b/tests/test_mcp_comments.py
@@ -1,0 +1,165 @@
+"""Tests for MCP comment and collaboration tools."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from penpot_mcp.server.mcp_server import PenpotMCPServer
+
+
+@pytest.fixture
+def mock_server():
+    """Create a mock PenpotMCPServer with a mock API."""
+    server = PenpotMCPServer(name="Test Server", test_mode=True)
+
+    # Mock the API methods
+    server.api.create_comment_thread = MagicMock(return_value={
+        'id': 'thread-123',
+        'file-id': 'file-456',
+        'page-id': 'page-789',
+        'position': {'x': 100, 'y': 200},
+        'content': 'Test comment'
+    })
+
+    server.api.add_comment = MagicMock(return_value={
+        'id': 'comment-123',
+        'thread-id': 'thread-456',
+        'content': 'Test reply',
+        'owner-name': 'Test User'
+    })
+
+    server.api.get_comment_threads = MagicMock(return_value=[
+        {'id': 'thread-1', 'position': {'x': 100, 'y': 200}},
+        {'id': 'thread-2', 'position': {'x': 300, 'y': 400}}
+    ])
+
+    server.api.update_comment_thread_status = MagicMock(return_value={
+        'id': 'thread-123',
+        'is-resolved': True
+    })
+
+    return server
+
+
+# ========== MCP TOOL TESTS ==========
+
+def test_add_design_comment_tool(mock_server):
+    """Test add_design_comment MCP tool."""
+    result = mock_server.api.create_comment_thread(
+        file_id='file-123',
+        page_id='page-456',
+        x=150,
+        y=200,
+        content='This button needs work'
+    )
+
+    assert result['id'] == 'thread-123'
+    assert result['position']['x'] == 100
+    assert result['content'] == 'Test comment'
+
+
+def test_reply_to_comment_tool(mock_server):
+    """Test reply_to_comment MCP tool."""
+    result = mock_server.api.add_comment(
+        thread_id='thread-456',
+        content='I agree with this feedback'
+    )
+
+    assert result['id'] == 'comment-123'
+    assert result['thread-id'] == 'thread-456'
+    assert result['content'] == 'Test reply'
+
+
+def test_get_file_comments_tool(mock_server):
+    """Test get_file_comments MCP tool."""
+    result = mock_server.api.get_comment_threads(
+        file_id='file-123',
+        page_id='page-456'
+    )
+
+    assert len(result) == 2
+    assert result[0]['id'] == 'thread-1'
+    assert result[1]['id'] == 'thread-2'
+
+
+def test_resolve_comment_thread_tool(mock_server):
+    """Test resolve_comment_thread MCP tool."""
+    result = mock_server.api.update_comment_thread_status(
+        thread_id='thread-123',
+        is_resolved=True
+    )
+
+    assert result['id'] == 'thread-123'
+    assert result['is-resolved'] is True
+
+
+# ========== INTEGRATION TESTS ==========
+
+class TestCommentWorkflow:
+    """Integration tests for comment workflow."""
+
+    def test_comment_workflow(self, mock_server):
+        """Test complete workflow: create thread, add comment, resolve."""
+        # Create comment thread
+        thread = mock_server.api.create_comment_thread(
+            file_id='file-123',
+            page_id='page-456',
+            x=100,
+            y=200,
+            content='Initial comment'
+        )
+        assert thread['id'] == 'thread-123'
+
+        # Add reply
+        comment = mock_server.api.add_comment(
+            thread_id=thread['id'],
+            content='Reply to comment'
+        )
+        assert comment['thread-id'] == 'thread-456'
+
+        # Resolve thread
+        resolved = mock_server.api.update_comment_thread_status(
+            thread_id=thread['id'],
+            is_resolved=True
+        )
+        assert resolved['is-resolved'] is True
+
+    def test_multiple_threads_workflow(self, mock_server):
+        """Test multiple comment threads on same page."""
+        # Get all threads
+        threads = mock_server.api.get_comment_threads(file_id='file-123')
+        assert len(threads) == 2
+
+        # Verify different positions
+        assert threads[0]['position'] != threads[1]['position']
+
+
+class TestCommentErrorHandling:
+    """Test error handling for comment tools."""
+
+    def test_create_comment_with_error(self, mock_server):
+        """Test that create_comment_thread handles errors."""
+        mock_server.api.create_comment_thread = MagicMock(
+            side_effect=Exception("API Error")
+        )
+
+        # Tool should handle the error gracefully
+        # (actual invocation would require calling through FastMCP)
+
+    def test_reply_with_invalid_thread(self, mock_server):
+        """Test that add_comment handles invalid thread ID."""
+        mock_server.api.add_comment = MagicMock(
+            side_effect=Exception("Thread not found")
+        )
+
+        # Tool should handle the error
+        # (actual invocation would require calling through FastMCP)
+
+    def test_resolve_nonexistent_thread(self, mock_server):
+        """Test that resolve handles nonexistent thread."""
+        mock_server.api.update_comment_thread_status = MagicMock(
+            side_effect=Exception("Thread not found")
+        )
+
+        # Tool should handle the error
+        # (actual invocation would require calling through FastMCP)

--- a/tests/test_mcp_comments.py
+++ b/tests/test_mcp_comments.py
@@ -41,10 +41,11 @@ def mock_server():
     return server
 
 
-# ========== MCP TOOL TESTS ==========
+# ========== API MOCK TESTS ==========
+# These tests verify the API mock behavior works correctly
 
-def test_add_design_comment_tool(mock_server):
-    """Test add_design_comment MCP tool."""
+def test_create_comment_thread_api_mock(mock_server):
+    """Test create_comment_thread API mock returns expected data."""
     result = mock_server.api.create_comment_thread(
         file_id='file-123',
         page_id='page-456',
@@ -58,8 +59,8 @@ def test_add_design_comment_tool(mock_server):
     assert result['content'] == 'Test comment'
 
 
-def test_reply_to_comment_tool(mock_server):
-    """Test reply_to_comment MCP tool."""
+def test_add_comment_api_mock(mock_server):
+    """Test add_comment API mock returns expected data."""
     result = mock_server.api.add_comment(
         thread_id='thread-456',
         content='I agree with this feedback'
@@ -70,8 +71,8 @@ def test_reply_to_comment_tool(mock_server):
     assert result['content'] == 'Test reply'
 
 
-def test_get_file_comments_tool(mock_server):
-    """Test get_file_comments MCP tool."""
+def test_get_comment_threads_api_mock(mock_server):
+    """Test get_comment_threads API mock returns expected data."""
     result = mock_server.api.get_comment_threads(
         file_id='file-123',
         page_id='page-456'
@@ -82,8 +83,8 @@ def test_get_file_comments_tool(mock_server):
     assert result[1]['id'] == 'thread-2'
 
 
-def test_resolve_comment_thread_tool(mock_server):
-    """Test resolve_comment_thread MCP tool."""
+def test_update_comment_thread_status_api_mock(mock_server):
+    """Test update_comment_thread_status API mock returns expected data."""
     result = mock_server.api.update_comment_thread_status(
         thread_id='thread-123',
         is_resolved=True
@@ -132,34 +133,3 @@ class TestCommentWorkflow:
 
         # Verify different positions
         assert threads[0]['position'] != threads[1]['position']
-
-
-class TestCommentErrorHandling:
-    """Test error handling for comment tools."""
-
-    def test_create_comment_with_error(self, mock_server):
-        """Test that create_comment_thread handles errors."""
-        mock_server.api.create_comment_thread = MagicMock(
-            side_effect=Exception("API Error")
-        )
-
-        # Tool should handle the error gracefully
-        # (actual invocation would require calling through FastMCP)
-
-    def test_reply_with_invalid_thread(self, mock_server):
-        """Test that add_comment handles invalid thread ID."""
-        mock_server.api.add_comment = MagicMock(
-            side_effect=Exception("Thread not found")
-        )
-
-        # Tool should handle the error
-        # (actual invocation would require calling through FastMCP)
-
-    def test_resolve_nonexistent_thread(self, mock_server):
-        """Test that resolve handles nonexistent thread."""
-        mock_server.api.update_comment_thread_status = MagicMock(
-            side_effect=Exception("Thread not found")
-        )
-
-        # Tool should handle the error
-        # (actual invocation would require calling through FastMCP)

--- a/tests/test_mcp_design_tools.py
+++ b/tests/test_mcp_design_tools.py
@@ -1,0 +1,307 @@
+"""Tests for MCP design modification tools."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from penpot_mcp.api.penpot_api import PenpotAPI
+
+
+@pytest.fixture
+def mock_api_client():
+    """Create a mock PenpotAPI client."""
+    with patch.object(PenpotAPI, 'login_with_password'):
+        api = PenpotAPI(debug=False)
+        api.access_token = "test-token"
+        
+        # Mock the editing_session context manager
+        api.editing_session = MagicMock()
+        api.editing_session.return_value.__enter__ = MagicMock(return_value=("session-123", 10))
+        api.editing_session.return_value.__exit__ = MagicMock(return_value=False)
+        
+        # Mock the update_file method
+        api.update_file = MagicMock(return_value={"id": "file-123", "revn": 11})
+        
+        return api
+
+
+def test_move_object_tool(mock_api_client):
+    """Test move_object MCP tool."""
+    # Create a callable that matches the tool implementation
+    def move_object(file_id: str, object_id: str, x: float, y: float):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                ops = [
+                    mock_api_client.create_set_operation('x', x),
+                    mock_api_client.create_set_operation('y', y)
+                ]
+                change = mock_api_client.create_mod_obj_change(object_id, ops)
+                result = mock_api_client.update_file(file_id, session_id, revn, [change])
+                
+                return {
+                    "success": True,
+                    "objectId": object_id,
+                    "revn": result.get('revn')
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    # Call the tool
+    result = move_object("file-123", "obj-456", 200, 150)
+    
+    # Verify result
+    assert result["success"] is True
+    assert result["objectId"] == "obj-456"
+    assert result["revn"] == 11
+    
+    # Verify API calls
+    mock_api_client.editing_session.assert_called_once_with("file-123")
+    mock_api_client.update_file.assert_called_once()
+
+
+def test_resize_object_tool(mock_api_client):
+    """Test resize_object MCP tool."""
+    def resize_object(file_id: str, object_id: str, width: float, height: float):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                ops = [
+                    mock_api_client.create_set_operation('width', width),
+                    mock_api_client.create_set_operation('height', height)
+                ]
+                change = mock_api_client.create_mod_obj_change(object_id, ops)
+                result = mock_api_client.update_file(file_id, session_id, revn, [change])
+                
+                return {
+                    "success": True,
+                    "objectId": object_id,
+                    "revn": result.get('revn')
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    result = resize_object("file-123", "obj-456", 300, 200)
+    
+    assert result["success"] is True
+    assert result["objectId"] == "obj-456"
+    assert result["revn"] == 11
+    
+    mock_api_client.update_file.assert_called_once()
+
+
+def test_change_color_tool(mock_api_client):
+    """Test change_object_color MCP tool."""
+    def change_object_color(file_id: str, object_id: str, fill_color: str, fill_opacity: float = 1.0):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                fills = [{
+                    'fillColor': fill_color,
+                    'fillOpacity': fill_opacity
+                }]
+                ops = [
+                    mock_api_client.create_set_operation('fills', fills)
+                ]
+                change = mock_api_client.create_mod_obj_change(object_id, ops)
+                result = mock_api_client.update_file(file_id, session_id, revn, [change])
+                
+                return {
+                    "success": True,
+                    "objectId": object_id,
+                    "revn": result.get('revn')
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    result = change_object_color("file-123", "obj-456", "#FF0000")
+    
+    assert result["success"] is True
+    assert result["objectId"] == "obj-456"
+    assert result["revn"] == 11
+
+
+def test_change_color_with_opacity(mock_api_client):
+    """Test change_object_color with custom opacity."""
+    def change_object_color(file_id: str, object_id: str, fill_color: str, fill_opacity: float = 1.0):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                fills = [{
+                    'fillColor': fill_color,
+                    'fillOpacity': fill_opacity
+                }]
+                ops = [
+                    mock_api_client.create_set_operation('fills', fills)
+                ]
+                change = mock_api_client.create_mod_obj_change(object_id, ops)
+                result = mock_api_client.update_file(file_id, session_id, revn, [change])
+                
+                return {
+                    "success": True,
+                    "objectId": object_id,
+                    "revn": result.get('revn')
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    result = change_object_color("file-123", "obj-456", "#00FF00", 0.5)
+    
+    assert result["success"] is True
+    assert result["revn"] == 11
+
+
+def test_rotate_object_tool(mock_api_client):
+    """Test rotate_object MCP tool."""
+    def rotate_object(file_id: str, object_id: str, rotation: float):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                ops = [
+                    mock_api_client.create_set_operation('rotation', rotation)
+                ]
+                change = mock_api_client.create_mod_obj_change(object_id, ops)
+                result = mock_api_client.update_file(file_id, session_id, revn, [change])
+                
+                return {
+                    "success": True,
+                    "objectId": object_id,
+                    "revn": result.get('revn')
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    result = rotate_object("file-123", "obj-456", 45)
+    
+    assert result["success"] is True
+    assert result["objectId"] == "obj-456"
+    assert result["revn"] == 11
+
+
+def test_delete_object_tool(mock_api_client):
+    """Test delete_object MCP tool."""
+    def delete_object(file_id: str, page_id: str, object_id: str):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                change = mock_api_client.create_del_obj_change(object_id, page_id)
+                result = mock_api_client.update_file(file_id, session_id, revn, [change])
+                
+                return {
+                    "success": True,
+                    "deletedObjectId": object_id,
+                    "revn": result.get('revn')
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    result = delete_object("file-123", "page-456", "obj-789")
+    
+    assert result["success"] is True
+    assert result["deletedObjectId"] == "obj-789"
+    assert result["revn"] == 11
+
+
+def test_batch_changes_tool(mock_api_client):
+    """Test apply_design_changes with multiple operations."""
+    def apply_design_changes(file_id: str, changes: list):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                result = mock_api_client.update_file(file_id, session_id, revn, changes)
+                
+                return {
+                    "success": True,
+                    "revn": result.get('revn'),
+                    "changesApplied": len(changes)
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    changes = [
+        {
+            "type": "add-obj",
+            "id": "obj-1",
+            "pageId": "page-1",
+            "obj": {"type": "rect", "x": 0, "y": 0}
+        },
+        {
+            "type": "mod-obj",
+            "id": "obj-2",
+            "operations": [{"type": "set", "attr": "x", "val": 100}]
+        }
+    ]
+    
+    result = apply_design_changes("file-123", changes)
+    
+    assert result["success"] is True
+    assert result["changesApplied"] == 2
+    assert result["revn"] == 11
+
+
+def test_batch_changes_empty_list(mock_api_client):
+    """Test apply_design_changes with empty list."""
+    def apply_design_changes(file_id: str, changes: list):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                result = mock_api_client.update_file(file_id, session_id, revn, changes)
+                
+                return {
+                    "success": True,
+                    "revn": result.get('revn'),
+                    "changesApplied": len(changes)
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    result = apply_design_changes("file-123", [])
+    
+    assert result["success"] is True
+    assert result["changesApplied"] == 0
+
+
+def test_move_object_error_handling(mock_api_client):
+    """Test move_object error handling."""
+    # Make update_file raise an exception
+    mock_api_client.update_file.side_effect = Exception("Test error")
+    
+    def move_object(file_id: str, object_id: str, x: float, y: float):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                ops = [
+                    mock_api_client.create_set_operation('x', x),
+                    mock_api_client.create_set_operation('y', y)
+                ]
+                change = mock_api_client.create_mod_obj_change(object_id, ops)
+                result = mock_api_client.update_file(file_id, session_id, revn, [change])
+                
+                return {
+                    "success": True,
+                    "objectId": object_id,
+                    "revn": result.get('revn')
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    result = move_object("file-123", "obj-456", 200, 150)
+    
+    assert "error" in result
+    assert result["error"] == "Test error"
+
+
+def test_delete_object_error_handling(mock_api_client):
+    """Test delete_object error handling."""
+    # Make update_file raise an exception
+    mock_api_client.update_file.side_effect = Exception("Delete failed")
+    
+    def delete_object(file_id: str, page_id: str, object_id: str):
+        try:
+            with mock_api_client.editing_session(file_id) as (session_id, revn):
+                change = mock_api_client.create_del_obj_change(object_id, page_id)
+                result = mock_api_client.update_file(file_id, session_id, revn, [change])
+                
+                return {
+                    "success": True,
+                    "deletedObjectId": object_id,
+                    "revn": result.get('revn')
+                }
+        except Exception as e:
+            return {"error": str(e)}
+    
+    result = delete_object("file-123", "page-456", "obj-789")
+    
+    assert "error" in result
+    assert result["error"] == "Delete failed"

--- a/tests/test_mcp_design_tools.py
+++ b/tests/test_mcp_design_tools.py
@@ -1,0 +1,279 @@
+"""Tests for MCP design tools (shape creation)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from penpot_mcp.server.mcp_server import PenpotMCPServer
+
+
+@pytest.fixture
+def mock_server():
+    """Create a mock PenpotMCPServer with a mock API."""
+    server = PenpotMCPServer(name="Test Server", test_mode=True)
+    
+    # Mock the API methods
+    server.api.generate_session_id = MagicMock(return_value="test-obj-id-123")
+    server.api.get_file = MagicMock(return_value={'id': 'file-123', 'revn': 1})
+    server.api.update_file = MagicMock(return_value={'revn': 2})
+    server.api.create_rectangle = MagicMock(return_value={
+        'type': 'rect',
+        'name': 'Rectangle',
+        'x': 100,
+        'y': 100,
+        'width': 200,
+        'height': 150
+    })
+    server.api.create_circle = MagicMock(return_value={
+        'type': 'circle',
+        'name': 'Circle',
+        'x': 100,
+        'y': 100,
+        'width': 100,
+        'height': 100
+    })
+    server.api.create_text = MagicMock(return_value={
+        'type': 'text',
+        'name': 'Text',
+        'x': 50,
+        'y': 50,
+        'content': 'Hello World'
+    })
+    server.api.create_frame = MagicMock(return_value={
+        'type': 'frame',
+        'name': 'Frame',
+        'x': 0,
+        'y': 0,
+        'width': 375,
+        'height': 812
+    })
+    server.api.create_add_obj_change = MagicMock(return_value={
+        'type': 'add-obj',
+        'id': 'test-obj-id-123',
+        'pageId': 'page-456',
+        'obj': {}
+    })
+    
+    return server
+
+
+class TestAddRectangleTool:
+    """Tests for add_rectangle MCP tool."""
+
+    def test_add_rectangle_basic(self, mock_server):
+        """Test basic rectangle creation."""
+        # Get the tool function from the server
+        # We need to manually invoke it since we can't call via MCP framework in tests
+        with patch.object(mock_server.api, 'editing_session') as mock_session:
+            mock_session.return_value.__enter__.return_value = ("session-123", 1)
+            
+            # Simulate calling the tool - we'll need to extract and call it directly
+            # For now, test the API methods are configured correctly
+            result = mock_server.api.create_rectangle(100, 100, 200, 150)
+            
+            assert result['type'] == 'rect'
+            assert result['name'] == 'Rectangle'
+            assert result['x'] == 100
+            assert result['y'] == 100
+            assert result['width'] == 200
+            assert result['height'] == 150
+
+    def test_add_rectangle_with_custom_fill(self, mock_server):
+        """Test rectangle with custom fill color."""
+        mock_server.api.create_rectangle.return_value = {
+            'type': 'rect',
+            'name': 'Rectangle',
+            'x': 100,
+            'y': 100,
+            'width': 200,
+            'height': 150,
+            'fills': [{'fillColor': '#FF0000'}]
+        }
+        
+        result = mock_server.api.create_rectangle(
+            100, 100, 200, 150,
+            fill_color="#FF0000"
+        )
+        
+        assert 'fills' in result
+        assert result['fills'][0]['fillColor'] == '#FF0000'
+
+    def test_add_rectangle_with_stroke(self, mock_server):
+        """Test rectangle with stroke."""
+        mock_server.api.create_rectangle.return_value = {
+            'type': 'rect',
+            'name': 'Rectangle',
+            'x': 100,
+            'y': 100,
+            'width': 200,
+            'height': 150,
+            'strokes': [{'strokeColor': '#000000', 'strokeWidth': 2}]
+        }
+        
+        result = mock_server.api.create_rectangle(
+            100, 100, 200, 150,
+            stroke_color="#000000",
+            stroke_width=2
+        )
+        
+        assert 'strokes' in result
+
+
+class TestAddCircleTool:
+    """Tests for add_circle MCP tool."""
+
+    def test_add_circle_basic(self, mock_server):
+        """Test basic circle creation."""
+        result = mock_server.api.create_circle(150, 150, 50)
+        
+        assert result['type'] == 'circle'
+        assert result['name'] == 'Circle'
+
+    def test_add_circle_with_custom_fill(self, mock_server):
+        """Test circle with custom fill color."""
+        mock_server.api.create_circle.return_value = {
+            'type': 'circle',
+            'name': 'Circle',
+            'x': 100,
+            'y': 100,
+            'width': 100,
+            'height': 100,
+            'fills': [{'fillColor': '#00FF00'}]
+        }
+        
+        result = mock_server.api.create_circle(
+            150, 150, 50,
+            fill_color="#00FF00"
+        )
+        
+        assert 'fills' in result
+        assert result['fills'][0]['fillColor'] == '#00FF00'
+
+
+class TestAddTextTool:
+    """Tests for add_text MCP tool."""
+
+    def test_add_text_basic(self, mock_server):
+        """Test basic text creation."""
+        result = mock_server.api.create_text(50, 50, "Hello World")
+        
+        assert result['type'] == 'text'
+        assert result['name'] == 'Text'
+        assert result['content'] == 'Hello World'
+
+    def test_add_text_with_custom_font(self, mock_server):
+        """Test text with custom font."""
+        mock_server.api.create_text.return_value = {
+            'type': 'text',
+            'name': 'Text',
+            'x': 50,
+            'y': 50,
+            'content': 'Hello World',
+            'fontSize': 24,
+            'fontFamily': 'Arial'
+        }
+        
+        result = mock_server.api.create_text(
+            50, 50, "Hello World",
+            font_size=24,
+            font_family="Arial"
+        )
+        
+        assert result['fontSize'] == 24
+        assert result['fontFamily'] == 'Arial'
+
+
+class TestAddFrameTool:
+    """Tests for add_frame MCP tool."""
+
+    def test_add_frame_basic(self, mock_server):
+        """Test basic frame creation."""
+        result = mock_server.api.create_frame(0, 0, 375, 812)
+        
+        assert result['type'] == 'frame'
+        assert result['name'] == 'Frame'
+        assert result['width'] == 375
+        assert result['height'] == 812
+
+    def test_add_frame_with_name(self, mock_server):
+        """Test frame with custom name."""
+        mock_server.api.create_frame.return_value = {
+            'type': 'frame',
+            'name': 'Mobile',
+            'x': 0,
+            'y': 0,
+            'width': 375,
+            'height': 812
+        }
+        
+        result = mock_server.api.create_frame(
+            0, 0, 375, 812,
+            name="Mobile"
+        )
+        
+        assert result['name'] == 'Mobile'
+
+
+class TestShapeCreationIntegration:
+    """Integration tests for shape creation tools."""
+
+    def test_create_rectangle_full_workflow(self, mock_server):
+        """Test full workflow for creating a rectangle."""
+        with patch.object(mock_server.api, 'editing_session') as mock_session:
+            mock_session.return_value.__enter__.return_value = ("session-123", 1)
+            
+            # Create rectangle
+            rect = mock_server.api.create_rectangle(100, 100, 200, 150)
+            obj_id = mock_server.api.generate_session_id()
+            change = mock_server.api.create_add_obj_change(obj_id, "page-456", rect)
+            
+            # Verify change structure
+            assert change['type'] == 'add-obj'
+            assert change['id'] == obj_id
+            assert change['pageId'] == 'page-456'
+            
+            # Update file
+            result = mock_server.api.update_file("file-123", "session-123", 1, [change])
+            
+            assert result['revn'] == 2
+
+    def test_create_shapes_with_frame_parent(self, mock_server):
+        """Test creating shapes with frame_id parent."""
+        with patch.object(mock_server.api, 'editing_session') as mock_session:
+            mock_session.return_value.__enter__.return_value = ("session-123", 1)
+            
+            # Create a frame first
+            frame = mock_server.api.create_frame(0, 0, 375, 812)
+            frame_id = mock_server.api.generate_session_id()
+            
+            # Create rectangle inside frame
+            rect = mock_server.api.create_rectangle(10, 10, 100, 100)
+            rect_id = mock_server.api.generate_session_id()
+            
+            # Create add change with frame_id
+            mock_server.api.create_add_obj_change.return_value = {
+                'type': 'add-obj',
+                'id': rect_id,
+                'pageId': 'page-456',
+                'frameId': frame_id,
+                'obj': rect
+            }
+            
+            change = mock_server.api.create_add_obj_change(
+                rect_id, "page-456", rect, frame_id=frame_id
+            )
+            
+            assert change['frameId'] == frame_id
+
+    def test_error_handling(self, mock_server):
+        """Test error handling in shape creation."""
+        with patch.object(mock_server.api, 'editing_session') as mock_session:
+            # Simulate an error
+            mock_session.side_effect = Exception("Test error")
+            
+            # This would normally be caught by _handle_api_error
+            with pytest.raises(Exception) as exc_info:
+                with mock_server.api.editing_session("file-123"):
+                    pass
+            
+            assert "Test error" in str(exc_info.value)

--- a/tests/test_mcp_libraries.py
+++ b/tests/test_mcp_libraries.py
@@ -48,10 +48,11 @@ def mock_server():
     return server
 
 
-# ========== MCP TOOL TESTS ==========
+# ========== API MOCK TESTS ==========
+# These tests verify the API mock behavior works correctly
 
-def test_link_library_tool(mock_server):
-    """Test link_library MCP tool."""
+def test_link_file_to_library_api_mock(mock_server):
+    """Test link_file_to_library API mock returns expected data."""
     result = mock_server.api.link_file_to_library(
         file_id='file-123',
         library_id='lib-456'
@@ -61,8 +62,8 @@ def test_link_library_tool(mock_server):
     assert 'lib-456' in result['linkedLibraries']
 
 
-def test_list_library_components_tool(mock_server):
-    """Test list_library_components MCP tool."""
+def test_get_library_components_api_mock(mock_server):
+    """Test get_library_components API mock returns expected data."""
     result = mock_server.api.get_library_components(
         library_id='lib-456'
     )
@@ -72,8 +73,8 @@ def test_list_library_components_tool(mock_server):
     assert result[2]['name'] == 'Modal'
 
 
-def test_import_component_tool(mock_server):
-    """Test import_component MCP tool."""
+def test_instantiate_component_api_mock(mock_server):
+    """Test instantiate_component API mock returns expected data."""
     result = mock_server.api.instantiate_component(
         file_id='file-123',
         page_id='page-456',
@@ -87,8 +88,8 @@ def test_import_component_tool(mock_server):
     assert result['revn'] == 6
 
 
-def test_import_component_tool_with_frame(mock_server):
-    """Test import_component MCP tool with frame_id."""
+def test_instantiate_component_with_frame_api_mock(mock_server):
+    """Test instantiate_component API mock with frame_id parameter."""
     result = mock_server.api.instantiate_component(
         file_id='file-123',
         page_id='page-456',
@@ -112,8 +113,8 @@ def test_import_component_tool_with_frame(mock_server):
     )
 
 
-def test_sync_library_tool(mock_server):
-    """Test sync_library MCP tool."""
+def test_sync_file_library_api_mock(mock_server):
+    """Test sync_file_library API mock returns expected data."""
     result = mock_server.api.sync_file_library(
         file_id='file-123',
         library_id='lib-456'
@@ -124,8 +125,8 @@ def test_sync_library_tool(mock_server):
     assert result['library-id'] == 'lib-456'
 
 
-def test_publish_as_library_tool(mock_server):
-    """Test publish_as_library MCP tool."""
+def test_publish_library_api_mock(mock_server):
+    """Test publish_library API mock returns expected data."""
     result = mock_server.api.publish_library(
         file_id='file-123',
         publish=True
@@ -135,14 +136,14 @@ def test_publish_as_library_tool(mock_server):
     assert result['is-shared'] is True
 
 
-def test_unpublish_library_tool(mock_server):
-    """Test unpublish_library MCP tool."""
+def test_unpublish_library_api_mock(mock_server):
+    """Test publish_library API mock with publish=False."""
     # Mock the unpublish response
     mock_server.api.publish_library = MagicMock(return_value={
         'id': 'file-123',
         'is-shared': False
     })
-    
+
     result = mock_server.api.publish_library(
         file_id='file-123',
         publish=False
@@ -152,8 +153,8 @@ def test_unpublish_library_tool(mock_server):
     assert result['is-shared'] is False
 
 
-def test_get_file_libraries_tool(mock_server):
-    """Test get_file_libraries MCP tool."""
+def test_get_file_libraries_api_mock(mock_server):
+    """Test get_file_libraries API mock returns expected data."""
     result = mock_server.api.get_file_libraries(
         file_id='file-123'
     )

--- a/tests/test_mcp_libraries.py
+++ b/tests/test_mcp_libraries.py
@@ -40,6 +40,11 @@ def mock_server():
         'is-shared': True
     })
 
+    server.api.get_file_libraries = MagicMock(return_value=[
+        {'id': 'lib-1', 'name': 'Design System'},
+        {'id': 'lib-2', 'name': 'Icon Library'}
+    ])
+
     return server
 
 
@@ -130,6 +135,34 @@ def test_publish_as_library_tool(mock_server):
     assert result['is-shared'] is True
 
 
+def test_unpublish_library_tool(mock_server):
+    """Test unpublish_library MCP tool."""
+    # Mock the unpublish response
+    mock_server.api.publish_library = MagicMock(return_value={
+        'id': 'file-123',
+        'is-shared': False
+    })
+    
+    result = mock_server.api.publish_library(
+        file_id='file-123',
+        publish=False
+    )
+
+    assert result['id'] == 'file-123'
+    assert result['is-shared'] is False
+
+
+def test_get_file_libraries_tool(mock_server):
+    """Test get_file_libraries MCP tool."""
+    result = mock_server.api.get_file_libraries(
+        file_id='file-123'
+    )
+
+    assert len(result) == 2
+    assert result[0]['name'] == 'Design System'
+    assert result[1]['name'] == 'Icon Library'
+
+
 def test_link_library_api_called_correctly(mock_server):
     """Test that link_library calls the API correctly."""
     mock_server.api.link_file_to_library.reset_mock()
@@ -210,6 +243,34 @@ def test_publish_as_library_api_called_correctly(mock_server):
     mock_server.api.publish_library.assert_called_once_with(
         file_id='test-file',
         publish=True
+    )
+
+
+def test_unpublish_library_api_called_correctly(mock_server):
+    """Test that unpublish_library calls the API correctly."""
+    mock_server.api.publish_library.reset_mock()
+    
+    mock_server.api.publish_library(
+        file_id='test-file',
+        publish=False
+    )
+
+    mock_server.api.publish_library.assert_called_once_with(
+        file_id='test-file',
+        publish=False
+    )
+
+
+def test_get_file_libraries_api_called_correctly(mock_server):
+    """Test that get_file_libraries calls the API correctly."""
+    mock_server.api.get_file_libraries.reset_mock()
+    
+    mock_server.api.get_file_libraries(
+        file_id='test-file'
+    )
+
+    mock_server.api.get_file_libraries.assert_called_once_with(
+        file_id='test-file'
     )
 
 

--- a/tests/test_mcp_libraries.py
+++ b/tests/test_mcp_libraries.py
@@ -1,0 +1,272 @@
+"""Tests for MCP library and component system tools."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from penpot_mcp.server.mcp_server import PenpotMCPServer
+
+
+@pytest.fixture
+def mock_server():
+    """Create a mock PenpotMCPServer with a mock API."""
+    server = PenpotMCPServer(name="Test Server", test_mode=True)
+
+    # Mock the library API methods
+    server.api.link_file_to_library = MagicMock(return_value={
+        'id': 'file-123',
+        'linkedLibraries': ['lib-456']
+    })
+
+    server.api.get_library_components = MagicMock(return_value=[
+        {'id': 'comp-1', 'name': 'Button'},
+        {'id': 'comp-2', 'name': 'Card'},
+        {'id': 'comp-3', 'name': 'Modal'}
+    ])
+
+    server.api.instantiate_component = MagicMock(return_value={
+        'id': 'file-123',
+        'revn': 6
+    })
+
+    server.api.sync_file_library = MagicMock(return_value={
+        'updated-count': 5,
+        'file-id': 'file-123',
+        'library-id': 'lib-456'
+    })
+
+    server.api.publish_library = MagicMock(return_value={
+        'id': 'file-123',
+        'is-shared': True
+    })
+
+    return server
+
+
+# ========== MCP TOOL TESTS ==========
+
+def test_link_library_tool(mock_server):
+    """Test link_library MCP tool."""
+    result = mock_server.api.link_file_to_library(
+        file_id='file-123',
+        library_id='lib-456'
+    )
+
+    assert result['id'] == 'file-123'
+    assert 'lib-456' in result['linkedLibraries']
+
+
+def test_list_library_components_tool(mock_server):
+    """Test list_library_components MCP tool."""
+    result = mock_server.api.get_library_components(
+        library_id='lib-456'
+    )
+
+    assert len(result) == 3
+    assert result[0]['name'] == 'Button'
+    assert result[2]['name'] == 'Modal'
+
+
+def test_import_component_tool(mock_server):
+    """Test import_component MCP tool."""
+    result = mock_server.api.instantiate_component(
+        file_id='file-123',
+        page_id='page-456',
+        library_id='lib-789',
+        component_id='comp-abc',
+        x=100,
+        y=200
+    )
+
+    assert result['id'] == 'file-123'
+    assert result['revn'] == 6
+
+
+def test_import_component_tool_with_frame(mock_server):
+    """Test import_component MCP tool with frame_id."""
+    result = mock_server.api.instantiate_component(
+        file_id='file-123',
+        page_id='page-456',
+        library_id='lib-789',
+        component_id='comp-abc',
+        x=100,
+        y=200,
+        frame_id='frame-xyz'
+    )
+
+    assert result['id'] == 'file-123'
+    # Verify frame_id was passed
+    mock_server.api.instantiate_component.assert_called_with(
+        file_id='file-123',
+        page_id='page-456',
+        library_id='lib-789',
+        component_id='comp-abc',
+        x=100,
+        y=200,
+        frame_id='frame-xyz'
+    )
+
+
+def test_sync_library_tool(mock_server):
+    """Test sync_library MCP tool."""
+    result = mock_server.api.sync_file_library(
+        file_id='file-123',
+        library_id='lib-456'
+    )
+
+    assert result['updated-count'] == 5
+    assert result['file-id'] == 'file-123'
+    assert result['library-id'] == 'lib-456'
+
+
+def test_publish_as_library_tool(mock_server):
+    """Test publish_as_library MCP tool."""
+    result = mock_server.api.publish_library(
+        file_id='file-123',
+        publish=True
+    )
+
+    assert result['id'] == 'file-123'
+    assert result['is-shared'] is True
+
+
+def test_link_library_api_called_correctly(mock_server):
+    """Test that link_library calls the API correctly."""
+    mock_server.api.link_file_to_library.reset_mock()
+    
+    mock_server.api.link_file_to_library(
+        file_id='test-file',
+        library_id='test-lib'
+    )
+
+    mock_server.api.link_file_to_library.assert_called_once_with(
+        file_id='test-file',
+        library_id='test-lib'
+    )
+
+
+def test_list_library_components_api_called_correctly(mock_server):
+    """Test that list_library_components calls the API correctly."""
+    mock_server.api.get_library_components.reset_mock()
+    
+    mock_server.api.get_library_components(
+        library_id='test-lib'
+    )
+
+    mock_server.api.get_library_components.assert_called_once_with(
+        library_id='test-lib'
+    )
+
+
+def test_import_component_api_called_correctly(mock_server):
+    """Test that import_component calls the API correctly."""
+    mock_server.api.instantiate_component.reset_mock()
+    
+    mock_server.api.instantiate_component(
+        file_id='test-file',
+        page_id='test-page',
+        library_id='test-lib',
+        component_id='test-comp',
+        x=50.0,
+        y=75.0,
+        frame_id=None
+    )
+
+    mock_server.api.instantiate_component.assert_called_once_with(
+        file_id='test-file',
+        page_id='test-page',
+        library_id='test-lib',
+        component_id='test-comp',
+        x=50.0,
+        y=75.0,
+        frame_id=None
+    )
+
+
+def test_sync_library_api_called_correctly(mock_server):
+    """Test that sync_library calls the API correctly."""
+    mock_server.api.sync_file_library.reset_mock()
+    
+    mock_server.api.sync_file_library(
+        file_id='test-file',
+        library_id='test-lib'
+    )
+
+    mock_server.api.sync_file_library.assert_called_once_with(
+        file_id='test-file',
+        library_id='test-lib'
+    )
+
+
+def test_publish_as_library_api_called_correctly(mock_server):
+    """Test that publish_as_library calls the API correctly."""
+    mock_server.api.publish_library.reset_mock()
+    
+    mock_server.api.publish_library(
+        file_id='test-file',
+        publish=True
+    )
+
+    mock_server.api.publish_library.assert_called_once_with(
+        file_id='test-file',
+        publish=True
+    )
+
+
+# ========== INTEGRATION TESTS ==========
+
+def test_library_workflow_integration(mock_server):
+    """Test complete workflow: link, list, import component."""
+    # Link library
+    link_result = mock_server.api.link_file_to_library('file-123', 'lib-456')
+    assert link_result['id'] == 'file-123'
+
+    # List components
+    components = mock_server.api.get_library_components('lib-456')
+    assert len(components) == 3
+
+    # Import a component
+    import_result = mock_server.api.instantiate_component(
+        file_id='file-123',
+        page_id='page-1',
+        library_id='lib-456',
+        component_id='comp-1',
+        x=100,
+        y=200
+    )
+    assert import_result['id'] == 'file-123'
+
+
+def test_component_sync_workflow(mock_server):
+    """Test workflow: link, import, then sync."""
+    # Link library
+    mock_server.api.link_file_to_library('file-123', 'lib-456')
+
+    # Import component
+    mock_server.api.instantiate_component(
+        file_id='file-123',
+        page_id='page-1',
+        library_id='lib-456',
+        component_id='comp-1',
+        x=100,
+        y=200
+    )
+
+    # Sync library
+    sync_result = mock_server.api.sync_file_library('file-123', 'lib-456')
+    assert sync_result['updated-count'] == 5
+
+
+def test_publish_and_use_workflow(mock_server):
+    """Test workflow: publish file as library, then use in another file."""
+    # Publish file as library
+    publish_result = mock_server.api.publish_library('lib-file', publish=True)
+    assert publish_result['is-shared'] is True
+
+    # Link to another file
+    link_result = mock_server.api.link_file_to_library('design-file', 'lib-file')
+    assert link_result['id'] == 'file-123'
+
+    # List and use components
+    components = mock_server.api.get_library_components('lib-file')
+    assert len(components) == 3

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1073,3 +1073,288 @@ def test_search_object_error_handling(mock_penpot_api):
     
     # Verify API was called
     mock_penpot_api.get_file.assert_called_with(file_id="file1")
+
+
+def test_create_file_tool(mock_penpot_api):
+    """Test create_file MCP tool."""
+    # Setup mock response
+    mock_penpot_api.create_file.return_value = {
+        "id": "new-file-123",
+        "name": "Test File",
+        "projectId": "project-123",
+        "created": "2024-01-01T00:00:00Z",
+        "modified": "2024-01-01T00:00:00Z"
+    }
+    
+    # Create mock cache
+    from penpot_mcp.utils.cache import MemoryCache
+    mock_cache = MemoryCache()
+    
+    # Create a callable that matches what would be registered
+    def create_file(name: str, project_id: str, is_shared: bool = False):
+        try:
+            result = mock_penpot_api.create_file(name, project_id, is_shared)
+            # Cache the newly created file
+            mock_cache.set(result['id'], result)
+            return result
+        except Exception as e:
+            return {"error": str(e)}
+    
+    # Call the handler
+    result = create_file("Test File", "project-123")
+    
+    # Check the result
+    assert isinstance(result, dict)
+    assert "id" in result
+    assert result["id"] == "new-file-123"
+    assert result["name"] == "Test File"
+    assert result["projectId"] == "project-123"
+    
+    # Verify API was called with correct parameters
+    mock_penpot_api.create_file.assert_called_once_with("Test File", "project-123", False)
+    
+    # Verify file was cached
+    cached = mock_cache.get("new-file-123")
+    assert cached is not None
+    assert cached["name"] == "Test File"
+
+
+def test_create_file_with_shared(mock_penpot_api):
+    """Test create_file MCP tool with is_shared parameter."""
+    # Setup mock response
+    mock_penpot_api.create_file.return_value = {
+        "id": "new-file-456",
+        "name": "Shared File",
+        "projectId": "project-123",
+        "isShared": True
+    }
+    
+    # Create mock cache
+    from penpot_mcp.utils.cache import MemoryCache
+    mock_cache = MemoryCache()
+    
+    # Create a callable that matches what would be registered
+    def create_file(name: str, project_id: str, is_shared: bool = False):
+        try:
+            result = mock_penpot_api.create_file(name, project_id, is_shared)
+            # Cache the newly created file
+            mock_cache.set(result['id'], result)
+            return result
+        except Exception as e:
+            return {"error": str(e)}
+    
+    # Call the handler with is_shared=True
+    result = create_file("Shared File", "project-123", is_shared=True)
+    
+    # Check the result
+    assert isinstance(result, dict)
+    assert result["id"] == "new-file-456"
+    assert result["isShared"] is True
+    
+    # Verify API was called with correct parameters
+    mock_penpot_api.create_file.assert_called_once_with("Shared File", "project-123", True)
+
+
+def test_delete_file_tool(mock_penpot_api):
+    """Test delete_file MCP tool."""
+    # Setup mock response
+    mock_penpot_api.delete_file.return_value = {"success": True, "id": "file-123"}
+    
+    # Create mock cache with existing file
+    from penpot_mcp.utils.cache import MemoryCache
+    mock_cache = MemoryCache()
+    mock_cache.set("file-123", {"id": "file-123", "name": "Old File"})
+    
+    # Create a callable that matches what would be registered
+    def delete_file(file_id: str):
+        try:
+            result = mock_penpot_api.delete_file(file_id)
+            # Remove from cache if present
+            if file_id in mock_cache._cache:
+                del mock_cache._cache[file_id]
+            return result
+        except Exception as e:
+            return {"error": str(e)}
+    
+    # Verify file is in cache before deletion
+    assert mock_cache.get("file-123") is not None
+    
+    # Call the handler
+    result = delete_file("file-123")
+    
+    # Check the result
+    assert isinstance(result, dict)
+    assert result["success"] is True
+    assert result["id"] == "file-123"
+    
+    # Verify API was called
+    mock_penpot_api.delete_file.assert_called_once_with("file-123")
+    
+    # Verify file was removed from cache
+    assert mock_cache.get("file-123") is None
+
+
+def test_rename_file_tool(mock_penpot_api):
+    """Test rename_file MCP tool."""
+    # Setup mock response
+    mock_penpot_api.rename_file.return_value = {
+        "id": "file-123",
+        "name": "New File Name",
+        "projectId": "project-123"
+    }
+    
+    # Create mock cache with existing file
+    from penpot_mcp.utils.cache import MemoryCache
+    mock_cache = MemoryCache()
+    mock_cache.set("file-123", {
+        "id": "file-123",
+        "data": {"name": "Old Name"}
+    })
+    
+    # Create a callable that matches what would be registered
+    def rename_file(file_id: str, name: str):
+        try:
+            result = mock_penpot_api.rename_file(file_id, name)
+            # Update cache if present - accessing internal _cache structure
+            if file_id in mock_cache._cache:
+                # Get the wrapped cache entry
+                cache_entry = mock_cache._cache[file_id]
+                # Update the nested data structure
+                if 'data' in cache_entry['data']:
+                    cache_entry['data']['data']['name'] = name
+            return result
+        except Exception as e:
+            return {"error": str(e)}
+    
+    # Call the handler
+    result = rename_file("file-123", "New File Name")
+    
+    # Check the result
+    assert isinstance(result, dict)
+    assert result["id"] == "file-123"
+    assert result["name"] == "New File Name"
+    
+    # Verify API was called
+    mock_penpot_api.rename_file.assert_called_once_with("file-123", "New File Name")
+    
+    # Verify cache was updated - get returns unwrapped data
+    cached = mock_cache.get("file-123")
+    assert cached["data"]["name"] == "New File Name"
+
+
+def test_list_teams_tool(mock_penpot_api):
+    """Test list_teams MCP tool."""
+    # Setup mock response
+    mock_penpot_api.get_teams.return_value = [
+        {"id": "team1", "name": "Team 1", "isDefault": True},
+        {"id": "team2", "name": "Team 2", "isDefault": False}
+    ]
+    
+    # Create a callable that matches what would be registered
+    def list_teams():
+        try:
+            teams = mock_penpot_api.get_teams()
+            return {"teams": teams}
+        except Exception as e:
+            return {"error": str(e)}
+    
+    # Call the handler
+    result = list_teams()
+    
+    # Check the result
+    assert isinstance(result, dict)
+    assert "teams" in result
+    assert len(result["teams"]) == 2
+    assert result["teams"][0]["id"] == "team1"
+    assert result["teams"][1]["id"] == "team2"
+    assert result["teams"][0]["isDefault"] is True
+    
+    # Verify API was called
+    mock_penpot_api.get_teams.assert_called_once()
+
+
+def test_create_project_tool(mock_penpot_api):
+    """Test create_project MCP tool."""
+    # Setup mock response
+    mock_penpot_api.create_project.return_value = {
+        "id": "new-project-123",
+        "name": "Test Project",
+        "teamId": "team-123",
+        "created": "2024-01-01T00:00:00Z"
+    }
+    
+    # Create a callable that matches what would be registered
+    def create_project(name: str, team_id: str):
+        try:
+            result = mock_penpot_api.create_project(name, team_id)
+            return result
+        except Exception as e:
+            return {"error": str(e)}
+    
+    # Call the handler
+    result = create_project("Test Project", "team-123")
+    
+    # Check the result
+    assert isinstance(result, dict)
+    assert "id" in result
+    assert result["id"] == "new-project-123"
+    assert result["name"] == "Test Project"
+    assert result["teamId"] == "team-123"
+    
+    # Verify API was called
+    mock_penpot_api.create_project.assert_called_once_with("Test Project", "team-123")
+
+
+def test_rename_project_tool(mock_penpot_api):
+    """Test rename_project MCP tool."""
+    # Setup mock response
+    mock_penpot_api.rename_project.return_value = {
+        "id": "project-123",
+        "name": "Renamed Project",
+        "teamId": "team-123"
+    }
+    
+    # Create a callable that matches what would be registered
+    def rename_project(project_id: str, name: str):
+        try:
+            result = mock_penpot_api.rename_project(project_id, name)
+            return result
+        except Exception as e:
+            return {"error": str(e)}
+    
+    # Call the handler
+    result = rename_project("project-123", "Renamed Project")
+    
+    # Check the result
+    assert isinstance(result, dict)
+    assert result["id"] == "project-123"
+    assert result["name"] == "Renamed Project"
+    
+    # Verify API was called
+    mock_penpot_api.rename_project.assert_called_once_with("project-123", "Renamed Project")
+
+
+def test_delete_project_tool(mock_penpot_api):
+    """Test delete_project MCP tool."""
+    # Setup mock response
+    mock_penpot_api.delete_project.return_value = {"success": True, "id": "project-123"}
+    
+    # Create a callable that matches what would be registered
+    def delete_project(project_id: str):
+        try:
+            result = mock_penpot_api.delete_project(project_id)
+            return result
+        except Exception as e:
+            return {"error": str(e)}
+    
+    # Call the handler
+    result = delete_project("project-123")
+    
+    # Check the result
+    assert isinstance(result, dict)
+    assert result["success"] is True
+    assert result["id"] == "project-123"
+    
+    # Verify API was called
+    mock_penpot_api.delete_project.assert_called_once_with("project-123")
+

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1206,9 +1206,10 @@ def test_rename_file_tool(mock_penpot_api):
     # Create mock cache with existing file
     from penpot_mcp.utils.cache import MemoryCache
     mock_cache = MemoryCache()
+    # Set cache correctly - no nested 'data' key in the data we're storing
     mock_cache.set("file-123", {
         "id": "file-123",
-        "data": {"name": "Old Name"}
+        "name": "Old Name"
     })
     
     # Create a callable that matches what would be registered
@@ -1217,11 +1218,8 @@ def test_rename_file_tool(mock_penpot_api):
             result = mock_penpot_api.rename_file(file_id, name)
             # Update cache if present - accessing internal _cache structure
             if file_id in mock_cache._cache:
-                # Get the wrapped cache entry
-                cache_entry = mock_cache._cache[file_id]
-                # Update the nested data structure
-                if 'data' in cache_entry['data']:
-                    cache_entry['data']['data']['name'] = name
+                # Update the name in the cache's data field
+                mock_cache._cache[file_id]['data']['name'] = name
             return result
         except Exception as e:
             return {"error": str(e)}
@@ -1239,7 +1237,8 @@ def test_rename_file_tool(mock_penpot_api):
     
     # Verify cache was updated - get returns unwrapped data
     cached = mock_cache.get("file-123")
-    assert cached["data"]["name"] == "New File Name"
+    assert cached["name"] == "New File Name"
+
 
 
 def test_list_teams_tool(mock_penpot_api):

--- a/tests/test_mcp_tool_implementation.py
+++ b/tests/test_mcp_tool_implementation.py
@@ -1,0 +1,388 @@
+"""Tests for actual MCP tool implementations.
+
+These tests verify that the MCP tools correctly wrap API calls,
+return proper response structures, and handle errors appropriately.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from penpot_mcp.server.mcp_server import PenpotMCPServer
+
+
+@pytest.fixture
+def mock_server():
+    """Create a PenpotMCPServer with mocked API."""
+    server = PenpotMCPServer(name="Test Server", test_mode=True)
+
+    # Mock all API methods we'll be testing
+    server.api.create_comment_thread = MagicMock()
+    server.api.add_comment = MagicMock()
+    server.api.get_comment_threads = MagicMock()
+    server.api.update_comment_thread_status = MagicMock()
+    server.api.link_file_to_library = MagicMock()
+    server.api.get_library_components = MagicMock()
+    server.api.instantiate_component = MagicMock()
+    server.api.sync_file_library = MagicMock()
+    server.api.publish_library = MagicMock()
+    server.api.get_file_libraries = MagicMock()
+
+    return server
+
+
+# Helper function to call a tool through the FastMCP server
+async def call_tool_async(server, tool_name, **kwargs):
+    """
+    Call a tool through the FastMCP server's call_tool method.
+
+    This is an async wrapper since FastMCP's call_tool is async.
+    """
+    import json
+    result = await server.mcp.call_tool(tool_name, kwargs)
+
+    # Result is a list of TextContent objects
+    if isinstance(result, list) and len(result) > 0:
+        # Extract text from first TextContent and parse as JSON
+        return json.loads(result[0].text)
+
+    return result
+
+
+def call_tool(server, tool_name, **kwargs):
+    """
+    Synchronous wrapper to call a tool.
+    """
+    import asyncio
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    return loop.run_until_complete(call_tool_async(server, tool_name, **kwargs))
+
+
+# ========== COMMENT TOOL TESTS ==========
+
+class TestCommentTools:
+    """Test comment and collaboration MCP tools."""
+
+    def test_add_design_comment_success(self, mock_server):
+        """Test add_design_comment tool returns correct structure on success."""
+        # Setup mock
+        mock_server.api.create_comment_thread.return_value = {
+            'id': 'thread-123',
+            'file-id': 'file-456',
+            'position': {'x': 100, 'y': 200},
+            'content': 'Test comment'
+        }
+
+        # Invoke the tool
+        result = call_tool(
+            mock_server,
+            'add_design_comment',
+            file_id='file-456',
+            page_id='page-789',
+            x=100.0,
+            y=200.0,
+            comment='Test comment'
+        )
+
+        # Verify structure
+        assert result['success'] is True
+        assert result['thread_id'] == 'thread-123'
+        assert 'thread' in result
+        assert result['thread']['id'] == 'thread-123'
+
+        # Verify API was called correctly
+        mock_server.api.create_comment_thread.assert_called_once_with(
+            'file-456', 'page-789', 100.0, 200.0, 'Test comment', None
+        )
+
+    def test_add_design_comment_with_frame(self, mock_server):
+        """Test add_design_comment tool with optional frame_id."""
+        mock_server.api.create_comment_thread.return_value = {
+            'id': 'thread-123',
+            'frame-id': 'frame-xyz'
+        }
+
+        result = call_tool(
+            mock_server,
+            'add_design_comment',
+            file_id='file-456',
+            page_id='page-789',
+            x=100.0,
+            y=200.0,
+            comment='Test',
+            frame_id='frame-xyz'
+        )
+
+        assert result['success'] is True
+        mock_server.api.create_comment_thread.assert_called_once_with(
+            'file-456', 'page-789', 100.0, 200.0, 'Test', 'frame-xyz'
+        )
+
+    def test_add_design_comment_error_handling(self, mock_server):
+        """Test add_design_comment tool handles API errors."""
+        mock_server.api.create_comment_thread.side_effect = Exception("API Error")
+
+        result = call_tool(
+            mock_server,
+            'add_design_comment',
+            file_id='file-456',
+            page_id='page-789',
+            x=100.0,
+            y=200.0,
+            comment='Test'
+        )
+
+        assert 'error' in result
+        assert result['error'] == 'API Error'
+
+    def test_reply_to_comment_success(self, mock_server):
+        """Test reply_to_comment tool returns correct structure."""
+        mock_server.api.add_comment.return_value = {
+            'id': 'comment-123',
+            'thread-id': 'thread-456',
+            'content': 'Test reply'
+        }
+
+        result = call_tool(
+            mock_server,
+            'reply_to_comment',
+            thread_id='thread-456',
+            reply='Test reply'
+        )
+
+        assert result['success'] is True
+        assert result['comment_id'] == 'comment-123'
+        assert 'comment' in result
+
+    def test_get_file_comments_success(self, mock_server):
+        """Test get_file_comments tool returns correct structure."""
+        mock_server.api.get_comment_threads.return_value = [
+            {'id': 'thread-1'},
+            {'id': 'thread-2'}
+        ]
+
+        result = call_tool(
+            mock_server,
+            'get_file_comments',
+            file_id='file-123'
+        )
+
+        assert result['success'] is True
+        assert result['count'] == 2
+        assert len(result['threads']) == 2
+
+    def test_get_file_comments_with_page_id(self, mock_server):
+        """Test get_file_comments tool with optional page_id."""
+        mock_server.api.get_comment_threads.return_value = [{'id': 'thread-1'}]
+
+        result = call_tool(
+            mock_server,
+            'get_file_comments',
+            file_id='file-123',
+            page_id='page-456'
+        )
+
+        assert result['success'] is True
+        mock_server.api.get_comment_threads.assert_called_once_with('file-123', 'page-456')
+
+    def test_resolve_comment_thread_success(self, mock_server):
+        """Test resolve_comment_thread tool returns correct structure."""
+        mock_server.api.update_comment_thread_status.return_value = {
+            'id': 'thread-123',
+            'is-resolved': True
+        }
+
+        result = call_tool(
+            mock_server,
+            'resolve_comment_thread',
+            thread_id='thread-123'
+        )
+
+        assert result['success'] is True
+        assert 'thread' in result
+        assert result['thread']['is-resolved'] is True
+
+        # Verify API called with is_resolved=True
+        mock_server.api.update_comment_thread_status.assert_called_once_with(
+            'thread-123', is_resolved=True
+        )
+
+
+# ========== LIBRARY TOOL TESTS ==========
+
+class TestLibraryTools:
+    """Test library and component system MCP tools."""
+
+    def test_link_library_success(self, mock_server):
+        """Test link_library tool returns correct structure."""
+        mock_server.api.link_file_to_library.return_value = {
+            'id': 'file-123',
+            'linkedLibraries': ['lib-456']
+        }
+
+        result = call_tool(
+            mock_server,
+            'link_library',
+            file_id='file-123',
+            library_id='lib-456'
+        )
+
+        assert result['success'] is True
+        assert 'result' in result
+        assert result['result']['id'] == 'file-123'
+
+    def test_list_library_components_success(self, mock_server):
+        """Test list_library_components tool returns correct structure."""
+        mock_server.api.get_library_components.return_value = [
+            {'id': 'comp-1', 'name': 'Button'},
+            {'id': 'comp-2', 'name': 'Card'}
+        ]
+
+        result = call_tool(
+            mock_server,
+            'list_library_components',
+            library_id='lib-456'
+        )
+
+        assert result['success'] is True
+        assert result['count'] == 2
+        assert len(result['components']) == 2
+        assert result['components'][0]['name'] == 'Button'
+
+    def test_import_component_success(self, mock_server):
+        """Test import_component tool returns correct structure."""
+        mock_server.api.instantiate_component.return_value = {
+            'id': 'file-123',
+            'revn': 6
+        }
+
+        result = call_tool(
+            mock_server,
+            'import_component',
+            file_id='file-123',
+            page_id='page-456',
+            library_id='lib-789',
+            component_id='comp-abc',
+            x=100.0,
+            y=200.0
+        )
+
+        assert result['success'] is True
+        assert 'file' in result
+        assert result['file']['revn'] == 6
+
+    def test_import_component_with_frame(self, mock_server):
+        """Test import_component tool with optional frame_id."""
+        mock_server.api.instantiate_component.return_value = {'id': 'file-123'}
+
+        result = call_tool(
+            mock_server,
+            'import_component',
+            file_id='file-123',
+            page_id='page-456',
+            library_id='lib-789',
+            component_id='comp-abc',
+            x=100.0,
+            y=200.0,
+            frame_id='frame-xyz'
+        )
+
+        assert result['success'] is True
+        mock_server.api.instantiate_component.assert_called_once_with(
+            'file-123', 'page-456', 'lib-789', 'comp-abc', 100.0, 200.0, 'frame-xyz'
+        )
+
+    def test_sync_library_success(self, mock_server):
+        """Test sync_library tool returns correct structure."""
+        mock_server.api.sync_file_library.return_value = {
+            'updated-count': 5,
+            'file-id': 'file-123'
+        }
+
+        result = call_tool(
+            mock_server,
+            'sync_library',
+            file_id='file-123',
+            library_id='lib-456'
+        )
+
+        assert result['success'] is True
+        assert 'result' in result
+        assert result['result']['updated-count'] == 5
+
+    def test_publish_as_library_success(self, mock_server):
+        """Test publish_as_library tool returns correct structure."""
+        mock_server.api.publish_library.return_value = {
+            'id': 'file-123',
+            'is-shared': True
+        }
+
+        result = call_tool(
+            mock_server,
+            'publish_as_library',
+            file_id='file-123'
+        )
+
+        assert result['success'] is True
+        assert 'file' in result
+        assert result['file']['is-shared'] is True
+
+        # Verify API called with publish=True
+        mock_server.api.publish_library.assert_called_once_with('file-123', publish=True)
+
+    def test_unpublish_library_success(self, mock_server):
+        """Test unpublish_library tool returns correct structure."""
+        mock_server.api.publish_library.return_value = {
+            'id': 'file-123',
+            'is-shared': False
+        }
+
+        result = call_tool(
+            mock_server,
+            'unpublish_library',
+            file_id='file-123'
+        )
+
+        assert result['success'] is True
+        assert 'file' in result
+        assert result['file']['is-shared'] is False
+
+        # Verify API called with publish=False
+        mock_server.api.publish_library.assert_called_once_with('file-123', publish=False)
+
+    def test_get_file_libraries_success(self, mock_server):
+        """Test get_file_libraries tool returns correct structure."""
+        mock_server.api.get_file_libraries.return_value = [
+            {'id': 'lib-1', 'name': 'Design System'},
+            {'id': 'lib-2', 'name': 'Icons'}
+        ]
+
+        result = call_tool(
+            mock_server,
+            'get_file_libraries',
+            file_id='file-123'
+        )
+
+        assert result['success'] is True
+        assert result['count'] == 2
+        assert len(result['libraries']) == 2
+        assert result['libraries'][0]['name'] == 'Design System'
+
+    def test_library_tool_error_handling(self, mock_server):
+        """Test library tools handle API errors correctly."""
+        mock_server.api.link_file_to_library.side_effect = Exception("Network error")
+
+        result = call_tool(
+            mock_server,
+            'link_library',
+            file_id='file-123',
+            library_id='lib-456'
+        )
+
+        assert 'error' in result
+        assert result['error'] == 'Network error'

--- a/tests/test_penpot_api.py
+++ b/tests/test_penpot_api.py
@@ -27,6 +27,344 @@ def api_client():
         return api
 
 
+class TestGetTeams:
+    """Tests for get_teams method."""
+
+    def test_get_teams_success(self, api_client, mock_response):
+        """Test getting teams."""
+        mock_response.json.return_value = [
+            {
+                'id': 'team-123',
+                'name': 'My Team',
+                'isDefault': True,
+                'permissions': ['read', 'write']
+            },
+            {
+                'id': 'team-456',
+                'name': 'Another Team',
+                'isDefault': False,
+                'permissions': ['read']
+            }
+        ]
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            teams = api_client.get_teams()
+
+            assert isinstance(teams, list)
+            assert len(teams) == 2
+            assert teams[0]['id'] == 'team-123'
+            assert teams[0]['name'] == 'My Team'
+            assert teams[0]['isDefault'] is True
+
+    def test_get_teams_empty(self, api_client, mock_response):
+        """Test getting teams when none exist."""
+        mock_response.json.return_value = []
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            teams = api_client.get_teams()
+
+            assert isinstance(teams, list)
+            assert len(teams) == 0
+
+
+class TestCreateProject:
+    """Tests for create_project method."""
+
+    def test_create_project_basic(self, api_client, mock_response):
+        """Test project creation."""
+        mock_response.json.return_value = {
+            'id': 'project-123',
+            'name': 'Test Project',
+            'teamId': 'team-456',
+            'created': '2024-01-01T00:00:00Z',
+            'modified': '2024-01-01T00:00:00Z'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_req:
+            result = api_client.create_project(name="Test Project", team_id="team-456")
+
+            assert result['name'] == "Test Project"
+            assert result['teamId'] == "team-456"
+            assert 'id' in result
+            assert result['id'] == 'project-123'
+
+            # Verify the payload structure
+            call_args = mock_req.call_args
+            payload = call_args.kwargs['json']
+            assert payload['name'] == "Test Project"
+            assert payload['team-id'] == "team-456"
+
+    def test_create_project_with_custom_id(self, api_client, mock_response):
+        """Test project creation with custom ID."""
+        mock_response.json.return_value = {
+            'id': 'custom-project-id',
+            'name': 'Custom Project',
+            'teamId': 'team-789'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_req:
+            result = api_client.create_project(
+                name="Custom Project",
+                team_id="team-789",
+                project_id='custom-project-id'
+            )
+
+            assert result['id'] == 'custom-project-id'
+            assert result['name'] == "Custom Project"
+
+            # Verify the payload includes the custom ID
+            call_args = mock_req.call_args
+            payload = call_args.kwargs['json']
+            assert payload['id'] == 'custom-project-id'
+
+    def test_create_project_handles_auth_error(self, api_client):
+        """Test that create_project handles authentication errors properly."""
+        with patch.object(api_client, '_make_authenticated_request', side_effect=requests.HTTPError()):
+            with pytest.raises(requests.HTTPError):
+                api_client.create_project(name="Test", team_id="team-123")
+
+
+class TestRenameProject:
+    """Tests for rename_project method."""
+
+    def test_rename_project_success(self, api_client, mock_response):
+        """Test project renaming."""
+        mock_response.json.return_value = {
+            'id': 'project-123',
+            'name': 'New Name',
+            'teamId': 'team-456'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_req:
+            result = api_client.rename_project(project_id="project-123", name="New Name")
+
+            assert result['name'] == "New Name"
+            assert result['id'] == 'project-123'
+
+            # Verify the payload structure
+            call_args = mock_req.call_args
+            payload = call_args.kwargs['json']
+            assert payload['name'] == "New Name"
+            assert payload['id'] == "project-123"
+
+    def test_rename_project_with_special_characters(self, api_client, mock_response):
+        """Test renaming project with special characters in name."""
+        new_name = "My Project (Copy) - 2024 [v1.0]"
+        mock_response.json.return_value = {
+            'id': 'project-789',
+            'name': new_name,
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.rename_project(project_id="project-789", name=new_name)
+
+            assert result['name'] == new_name
+
+
+class TestDeleteProject:
+    """Tests for delete_project method."""
+
+    def test_delete_project_success(self, api_client, mock_response):
+        """Test project deletion."""
+        mock_response.json.return_value = {'success': True, 'id': 'project-123'}
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_req:
+            result = api_client.delete_project(project_id="project-123")
+
+            assert result['success'] is True
+            assert result['id'] == 'project-123'
+
+            # Verify the payload structure
+            call_args = mock_req.call_args
+            payload = call_args.kwargs['json']
+            assert payload['id'] == "project-123"
+
+    def test_delete_project_empty_response(self, api_client, mock_response):
+        """Test project deletion with empty response (common for DELETE operations)."""
+        mock_response.json.side_effect = Exception("No JSON content")
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.delete_project(project_id="project-456")
+
+            assert result['success'] is True
+            assert result['id'] == 'project-456'
+
+    def test_delete_project_not_found(self, api_client):
+        """Test deletion of non-existent project."""
+        http_error = requests.HTTPError()
+        http_error.response = MagicMock()
+        http_error.response.status_code = 404
+
+        with patch.object(api_client, '_make_authenticated_request', side_effect=http_error):
+            with pytest.raises(requests.HTTPError):
+                api_client.delete_project(project_id="non-existent-project")
+
+
+class TestGetProjectDirect:
+    """Tests for get_project direct API call method."""
+
+    def test_get_project_direct_success(self, api_client, mock_response):
+        """Test getting single project directly."""
+        mock_response.json.return_value = {
+            'id': 'project-123',
+            'name': 'Test Project',
+            'teamId': 'team-456',
+            'permissions': ['read', 'write']
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_req:
+            result = api_client.get_project(project_id="project-123")
+
+            assert result['id'] == "project-123"
+            assert result['name'] == "Test Project"
+            assert 'permissions' in result
+
+            # Verify the payload structure
+            call_args = mock_req.call_args
+            payload = call_args.kwargs['json']
+            assert payload['id'] == "project-123"
+
+    def test_get_project_not_found(self, api_client):
+        """Test getting non-existent project."""
+        http_error = requests.HTTPError()
+        http_error.response = MagicMock()
+        http_error.response.status_code = 404
+
+        with patch.object(api_client, '_make_authenticated_request', side_effect=http_error):
+            with pytest.raises(requests.HTTPError):
+                api_client.get_project(project_id="non-existent")
+
+
+class TestProjectCRUDIntegration:
+    """Integration tests for project CRUD operations workflow."""
+
+    def test_project_lifecycle(self, api_client):
+        """Test complete project lifecycle: create -> rename -> delete."""
+        # Create project
+        create_response = MagicMock(spec=requests.Response)
+        create_response.status_code = 200
+        create_response.json.return_value = {
+            'id': 'new-project-123',
+            'name': 'Initial Name',
+            'teamId': 'team-456'
+        }
+
+        # Rename project
+        rename_response = MagicMock(spec=requests.Response)
+        rename_response.status_code = 200
+        rename_response.json.return_value = {
+            'id': 'new-project-123',
+            'name': 'Renamed Project',
+            'teamId': 'team-456'
+        }
+
+        # Delete project
+        delete_response = MagicMock(spec=requests.Response)
+        delete_response.status_code = 200
+        delete_response.json.return_value = {'success': True, 'id': 'new-project-123'}
+
+        with patch.object(api_client, '_make_authenticated_request') as mock_req:
+            mock_req.side_effect = [create_response, rename_response, delete_response]
+
+            # Create
+            project = api_client.create_project(name="Initial Name", team_id="team-456")
+            assert project['id'] == 'new-project-123'
+            assert project['name'] == 'Initial Name'
+
+            # Rename
+            renamed = api_client.rename_project(project_id=project['id'], name="Renamed Project")
+            assert renamed['name'] == 'Renamed Project'
+
+            # Delete
+            deleted = api_client.delete_project(project_id=project['id'])
+            assert deleted['success'] is True
+
+
+class TestProjectErrorHandling:
+    """Tests for error handling in project operations."""
+
+    def test_create_project_cloudflare_error(self, api_client):
+        """Test CloudFlare error handling in create_project."""
+        with patch.object(api_client, '_make_authenticated_request', side_effect=CloudFlareError("CloudFlare block", 403)):
+            with pytest.raises(CloudFlareError):
+                api_client.create_project(name="Test", team_id="team-123")
+
+    def test_delete_project_permission_denied(self, api_client):
+        """Test permission denied error in delete_project."""
+        http_error = requests.HTTPError()
+        http_error.response = MagicMock()
+        http_error.response.status_code = 403
+
+        with patch.object(api_client, '_make_authenticated_request', side_effect=http_error):
+            with pytest.raises(requests.HTTPError):
+                api_client.delete_project(project_id="project-123")
+
+    def test_rename_project_not_found(self, api_client):
+        """Test project not found error in rename_project."""
+        http_error = requests.HTTPError()
+        http_error.response = MagicMock()
+        http_error.response.status_code = 404
+
+        with patch.object(api_client, '_make_authenticated_request', side_effect=http_error):
+            with pytest.raises(requests.HTTPError):
+                api_client.rename_project(project_id="non-existent", name="New Name")
+
+
+class TestProjectDebugLogging:
+    """Tests for debug logging in project operations."""
+
+    def test_get_teams_debug_logging(self, mock_response, capsys):
+        """Test that debug logging works in get_teams."""
+        mock_response.json.return_value = [
+            {'id': 'team-123', 'name': 'Test Team', 'isDefault': True}
+        ]
+
+        with patch.object(PenpotAPI, 'login_with_password'):
+            api = PenpotAPI(debug=True)
+            api.access_token = "test-token"
+
+            with patch.object(api, '_make_authenticated_request', return_value=mock_response):
+                api.get_teams()
+
+                captured = capsys.readouterr()
+                assert "Retrieved 1 teams" in captured.out
+                assert "Test Team" in captured.out
+
+    def test_create_project_debug_logging(self, mock_response, capsys):
+        """Test that debug logging works in create_project."""
+        mock_response.json.return_value = {
+            'id': 'project-123',
+            'name': 'Test Project',
+            'teamId': 'team-456'
+        }
+
+        with patch.object(PenpotAPI, 'login_with_password'):
+            api = PenpotAPI(debug=True)
+            api.access_token = "test-token"
+
+            with patch.object(api, '_make_authenticated_request', return_value=mock_response):
+                api.create_project(name="Test Project", team_id="team-456")
+
+                captured = capsys.readouterr()
+                assert "Project created:" in captured.out
+                assert "Test Project" in captured.out
+
+    def test_delete_project_debug_logging(self, mock_response, capsys):
+        """Test that debug logging works in delete_project."""
+        mock_response.json.return_value = {'success': True, 'id': 'project-123'}
+
+        with patch.object(PenpotAPI, 'login_with_password'):
+            api = PenpotAPI(debug=True)
+            api.access_token = "test-token"
+
+            with patch.object(api, '_make_authenticated_request', return_value=mock_response):
+                api.delete_project(project_id="project-123")
+
+                captured = capsys.readouterr()
+                assert "Project deleted:" in captured.out
+                assert "project-123" in captured.out
+
+
 class TestCreateFile:
     """Tests for create_file method."""
 

--- a/tests/test_penpot_api.py
+++ b/tests/test_penpot_api.py
@@ -1,0 +1,327 @@
+"""Tests for the Penpot API client file CRUD operations."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from penpot_mcp.api.penpot_api import CloudFlareError, PenpotAPI, PenpotAPIError
+
+
+@pytest.fixture
+def mock_response():
+    """Create a mock response object."""
+    mock_resp = MagicMock(spec=requests.Response)
+    mock_resp.status_code = 200
+    mock_resp.headers = {}
+    return mock_resp
+
+
+@pytest.fixture
+def api_client():
+    """Create a PenpotAPI client for testing."""
+    with patch.object(PenpotAPI, 'login_with_password'):
+        api = PenpotAPI(debug=True)
+        api.access_token = "test-token"
+        return api
+
+
+class TestCreateFile:
+    """Tests for create_file method."""
+
+    def test_create_file_basic(self, api_client, mock_response):
+        """Test basic file creation."""
+        mock_response.json.return_value = {
+            'id': 'file-123',
+            'name': 'Test File',
+            'projectId': 'project-456',
+            'created': '2024-01-01T00:00:00Z',
+            'modified': '2024-01-01T00:00:00Z',
+            'isShared': False
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.create_file(name="Test File", project_id="project-456")
+
+            assert result['name'] == "Test File"
+            assert result['projectId'] == "project-456"
+            assert 'id' in result
+            assert result['id'] == 'file-123'
+
+    def test_create_file_with_optional_params(self, api_client, mock_response):
+        """Test file creation with optional parameters."""
+        mock_response.json.return_value = {
+            'id': 'custom-file-id',
+            'name': 'Shared File',
+            'projectId': 'project-789',
+            'isShared': True,
+            'features': ['feature1', 'feature2']
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_req:
+            result = api_client.create_file(
+                name="Shared File",
+                project_id="project-789",
+                is_shared=True,
+                features=['feature1', 'feature2'],
+                file_id='custom-file-id'
+            )
+
+            assert result['name'] == "Shared File"
+            assert result['isShared'] is True
+            assert 'features' in result
+
+            # Verify the payload structure
+            call_args = mock_req.call_args
+            payload = call_args.kwargs['json']
+            assert payload['name'] == "Shared File"
+            assert payload['project-id'] == "project-789"
+            assert payload['is-shared'] is True
+            assert payload['id'] == 'custom-file-id'
+            assert payload['features'] == ['feature1', 'feature2']
+
+    def test_create_file_handles_auth_error(self, api_client):
+        """Test that create_file handles authentication errors properly."""
+        with patch.object(api_client, '_make_authenticated_request', side_effect=requests.HTTPError()):
+            with pytest.raises(requests.HTTPError):
+                api_client.create_file(name="Test", project_id="project-123")
+
+
+class TestDeleteFile:
+    """Tests for delete_file method."""
+
+    def test_delete_file_success(self, api_client, mock_response):
+        """Test successful file deletion."""
+        mock_response.json.return_value = {'success': True, 'id': 'file-123'}
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.delete_file(file_id="file-123")
+
+            assert result['success'] is True
+            assert result['id'] == 'file-123'
+
+    def test_delete_file_empty_response(self, api_client, mock_response):
+        """Test file deletion with empty response (common for DELETE operations)."""
+        mock_response.json.side_effect = Exception("No JSON content")
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.delete_file(file_id="file-456")
+
+            assert result['success'] is True
+            assert result['id'] == 'file-456'
+
+    def test_delete_file_not_found(self, api_client):
+        """Test deletion of non-existent file."""
+        http_error = requests.HTTPError()
+        http_error.response = MagicMock()
+        http_error.response.status_code = 404
+
+        with patch.object(api_client, '_make_authenticated_request', side_effect=http_error):
+            with pytest.raises(requests.HTTPError):
+                api_client.delete_file(file_id="non-existent-file")
+
+
+class TestRenameFile:
+    """Tests for rename_file method."""
+
+    def test_rename_file_success(self, api_client, mock_response):
+        """Test successful file renaming."""
+        mock_response.json.return_value = {
+            'id': 'file-123',
+            'name': 'New File Name',
+            'projectId': 'project-456'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.rename_file(file_id="file-123", name="New File Name")
+
+            assert result['name'] == "New File Name"
+            assert result['id'] == 'file-123'
+
+    def test_rename_file_with_special_characters(self, api_client, mock_response):
+        """Test renaming file with special characters in name."""
+        new_name = "My File (Copy) - 2024 [v1.0]"
+        mock_response.json.return_value = {
+            'id': 'file-789',
+            'name': new_name,
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_req:
+            result = api_client.rename_file(file_id="file-789", name=new_name)
+
+            assert result['name'] == new_name
+
+            # Verify the payload structure
+            call_args = mock_req.call_args
+            payload = call_args.kwargs['json']
+            assert payload['name'] == new_name
+            assert payload['id'] == "file-789"
+
+
+class TestSetFileShared:
+    """Tests for set_file_shared method."""
+
+    def test_set_file_shared_true(self, api_client, mock_response):
+        """Test setting file to shared."""
+        mock_response.json.return_value = {
+            'id': 'file-123',
+            'isShared': True,
+            'name': 'Shared File'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            result = api_client.set_file_shared(file_id="file-123", is_shared=True)
+
+            assert result['isShared'] is True
+            assert result['id'] == 'file-123'
+
+    def test_set_file_shared_false(self, api_client, mock_response):
+        """Test setting file to not shared."""
+        mock_response.json.return_value = {
+            'id': 'file-456',
+            'isShared': False,
+            'name': 'Private File'
+        }
+
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_req:
+            result = api_client.set_file_shared(file_id="file-456", is_shared=False)
+
+            assert result['isShared'] is False
+
+            # Verify the payload structure
+            call_args = mock_req.call_args
+            payload = call_args.kwargs['json']
+            assert payload['is-shared'] is False
+            assert payload['id'] == "file-456"
+
+
+class TestCRUDIntegration:
+    """Integration tests for CRUD operations workflow."""
+
+    def test_create_rename_delete_workflow(self, api_client, mock_response):
+        """Test complete workflow: create -> rename -> delete."""
+        # Create file
+        create_response = MagicMock(spec=requests.Response)
+        create_response.status_code = 200
+        create_response.json.return_value = {
+            'id': 'new-file-123',
+            'name': 'Initial Name',
+            'projectId': 'project-456'
+        }
+
+        # Rename file
+        rename_response = MagicMock(spec=requests.Response)
+        rename_response.status_code = 200
+        rename_response.json.return_value = {
+            'id': 'new-file-123',
+            'name': 'Renamed File',
+            'projectId': 'project-456'
+        }
+
+        # Delete file
+        delete_response = MagicMock(spec=requests.Response)
+        delete_response.status_code = 200
+        delete_response.json.return_value = {'success': True, 'id': 'new-file-123'}
+
+        with patch.object(api_client, '_make_authenticated_request') as mock_req:
+            mock_req.side_effect = [create_response, rename_response, delete_response]
+
+            # Create
+            file = api_client.create_file(name="Initial Name", project_id="project-456")
+            assert file['id'] == 'new-file-123'
+            assert file['name'] == 'Initial Name'
+
+            # Rename
+            renamed = api_client.rename_file(file_id=file['id'], name="Renamed File")
+            assert renamed['name'] == 'Renamed File'
+
+            # Delete
+            deleted = api_client.delete_file(file_id=file['id'])
+            assert deleted['success'] is True
+
+
+class TestErrorHandling:
+    """Tests for error handling in CRUD operations."""
+
+    def test_create_file_cloudflare_error(self, api_client):
+        """Test CloudFlare error handling in create_file."""
+        with patch.object(api_client, '_make_authenticated_request', side_effect=CloudFlareError("CloudFlare block", 403)):
+            with pytest.raises(CloudFlareError):
+                api_client.create_file(name="Test", project_id="project-123")
+
+    def test_delete_file_permission_denied(self, api_client):
+        """Test permission denied error in delete_file."""
+        http_error = requests.HTTPError()
+        http_error.response = MagicMock()
+        http_error.response.status_code = 403
+
+        with patch.object(api_client, '_make_authenticated_request', side_effect=http_error):
+            with pytest.raises(requests.HTTPError):
+                api_client.delete_file(file_id="file-123")
+
+    def test_rename_file_project_not_found(self, api_client):
+        """Test project not found error in rename_file."""
+        http_error = requests.HTTPError()
+        http_error.response = MagicMock()
+        http_error.response.status_code = 404
+
+        with patch.object(api_client, '_make_authenticated_request', side_effect=http_error):
+            with pytest.raises(requests.HTTPError):
+                api_client.rename_file(file_id="non-existent", name="New Name")
+
+
+class TestDebugLogging:
+    """Tests for debug logging in CRUD operations."""
+
+    def test_create_file_debug_logging(self, mock_response, capsys):
+        """Test that debug logging works in create_file."""
+        mock_response.json.return_value = {
+            'id': 'file-123',
+            'name': 'Test File',
+            'projectId': 'project-456'
+        }
+
+        with patch.object(PenpotAPI, 'login_with_password'):
+            api = PenpotAPI(debug=True)
+            api.access_token = "test-token"
+
+            with patch.object(api, '_make_authenticated_request', return_value=mock_response):
+                api.create_file(name="Test File", project_id="project-456")
+
+                captured = capsys.readouterr()
+                assert "File created:" in captured.out
+                assert "Test File" in captured.out
+
+    def test_delete_file_debug_logging(self, mock_response, capsys):
+        """Test that debug logging works in delete_file."""
+        mock_response.json.return_value = {'success': True, 'id': 'file-123'}
+
+        with patch.object(PenpotAPI, 'login_with_password'):
+            api = PenpotAPI(debug=True)
+            api.access_token = "test-token"
+
+            with patch.object(api, '_make_authenticated_request', return_value=mock_response):
+                api.delete_file(file_id="file-123")
+
+                captured = capsys.readouterr()
+                assert "File deleted:" in captured.out
+                assert "file-123" in captured.out
+
+    def test_set_file_shared_debug_logging(self, mock_response, capsys):
+        """Test that debug logging works in set_file_shared."""
+        mock_response.json.return_value = {
+            'id': 'file-123',
+            'isShared': True
+        }
+
+        with patch.object(PenpotAPI, 'login_with_password'):
+            api = PenpotAPI(debug=True)
+            api.access_token = "test-token"
+
+            with patch.object(api, '_make_authenticated_request', return_value=mock_response):
+                api.set_file_shared(file_id="file-123", is_shared=True)
+
+                captured = capsys.readouterr()
+                assert "File set to shared:" in captured.out
+                assert "file-123" in captured.out

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -1,0 +1,174 @@
+"""Tests for session and revision management."""
+
+from unittest.mock import patch
+
+import pytest
+
+from penpot_mcp.api.penpot_api import PenpotAPI
+
+
+@pytest.fixture
+def api_client():
+    """Create a PenpotAPI client for testing."""
+    with patch.object(PenpotAPI, 'login_with_password'):
+        api = PenpotAPI(debug=True)
+        api.access_token = "test-token"
+        return api
+
+
+class TestGenerateSessionId:
+    """Tests for generate_session_id method."""
+
+    def test_generate_session_id(self, api_client):
+        """Test session ID generation."""
+        session_id = api_client.generate_session_id()
+        
+        # Should be valid UUID format
+        assert isinstance(session_id, str)
+        assert len(session_id) == 36  # UUID format
+        assert session_id.count('-') == 4
+        
+    def test_generate_session_id_unique(self, api_client):
+        """Test that generated session IDs are unique."""
+        session_id1 = api_client.generate_session_id()
+        session_id2 = api_client.generate_session_id()
+        
+        assert session_id1 != session_id2
+
+
+class TestGetFileRevision:
+    """Tests for get_file_revision method."""
+
+    def test_get_file_revision(self, api_client):
+        """Test getting file revision number."""
+        # Mock get_file to return data with revn
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 42}):
+            revn = api_client.get_file_revision("file-123")
+            
+            assert revn == 42
+
+    def test_get_file_revision_default(self, api_client):
+        """Test revision defaults to 0 if not present."""
+        # Mock get_file to return data without revn
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123'}):
+            revn = api_client.get_file_revision("file-123")
+            
+            assert revn == 0
+
+    def test_get_file_revision_zero(self, api_client):
+        """Test that revision number 0 is handled correctly."""
+        # Mock get_file to return data with revn=0
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 0}):
+            revn = api_client.get_file_revision("file-123")
+            
+            assert revn == 0
+
+    def test_get_file_revision_large_number(self, api_client):
+        """Test with large revision numbers."""
+        # Mock get_file to return data with large revn
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 9999}):
+            revn = api_client.get_file_revision("file-123")
+            
+            assert revn == 9999
+
+    def test_get_file_revision_debug_logging(self, api_client, capsys):
+        """Test that debug logging works in get_file_revision."""
+        # Mock get_file to return data with revn
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 10}):
+            api_client.get_file_revision("file-123")
+            
+            captured = capsys.readouterr()
+            assert "Current revision for file file-123: 10" in captured.out
+
+
+class TestEditingSessionContext:
+    """Tests for editing_session context manager."""
+
+    def test_editing_session_context(self, api_client):
+        """Test editing session context manager."""
+        # Mock get_file
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 10}):
+            with api_client.editing_session("file-123") as (session_id, revn):
+                assert isinstance(session_id, str)
+                assert len(session_id) == 36
+                assert revn == 10
+
+    def test_editing_session_yields_correct_data(self, api_client):
+        """Test that context manager provides usable data."""
+        with patch.object(api_client, 'get_file', return_value={'id': 'test-file', 'revn': 5}):
+            file_id = "test-file"
+            
+            with api_client.editing_session(file_id) as (session_id, revn):
+                # Should be able to use these in update_file call
+                assert session_id is not None
+                assert revn == 5
+                
+                # Simulate what update_file would do
+                next_revn = revn + 1
+                assert next_revn == 6
+
+    def test_editing_session_cleanup(self, api_client):
+        """Test that context manager cleanup works."""
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 3}):
+            try:
+                with api_client.editing_session("file-123") as (session_id, revn):
+                    assert session_id is not None
+                    assert revn == 3
+            except Exception:
+                pytest.fail("Context manager cleanup failed")
+
+    def test_editing_session_with_exception(self, api_client):
+        """Test that context manager handles exceptions properly."""
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 7}):
+            with pytest.raises(ValueError):
+                with api_client.editing_session("file-123") as (session_id, revn):
+                    # Simulate an error during editing
+                    raise ValueError("Simulated error")
+
+    def test_editing_session_debug_logging(self, api_client, capsys):
+        """Test that debug logging works in editing_session."""
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 15}):
+            with api_client.editing_session("file-123") as (session_id, revn):
+                pass
+            
+            captured = capsys.readouterr()
+            assert "Starting editing session" in captured.out
+            assert "at revision 15" in captured.out
+            assert "Ending editing session" in captured.out
+
+    def test_editing_session_unique_ids(self, api_client):
+        """Test that each context manager generates unique session IDs."""
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 1}):
+            with api_client.editing_session("file-123") as (session_id1, _):
+                with api_client.editing_session("file-123") as (session_id2, _):
+                    assert session_id1 != session_id2
+
+
+class TestSessionManagementIntegration:
+    """Integration tests for session and revision management."""
+
+    def test_session_workflow(self, api_client):
+        """Test typical session workflow."""
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 5}):
+            # Generate a session ID
+            session_id = api_client.generate_session_id()
+            assert session_id is not None
+            
+            # Get revision number
+            revn = api_client.get_file_revision("file-123")
+            assert revn == 5
+            
+            # Verify they can be used together
+            assert isinstance(session_id, str)
+            assert isinstance(revn, int)
+
+    def test_context_manager_workflow(self, api_client):
+        """Test workflow using context manager."""
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 10}):
+            with api_client.editing_session("file-123") as (session_id, revn):
+                # Verify we have valid session data
+                assert len(session_id) == 36
+                assert revn == 10
+                
+                # Could be used for update_file in the future
+                # api.update_file(file_id, session_id, revn, changes)

--- a/tests/test_shape_helpers.py
+++ b/tests/test_shape_helpers.py
@@ -1,0 +1,387 @@
+"""Tests for shape creation helper methods."""
+
+from unittest.mock import patch
+
+import pytest
+
+from penpot_mcp.api.penpot_api import PenpotAPI
+
+
+@pytest.fixture
+def api_client():
+    """Create a PenpotAPI client for testing."""
+    with patch.object(PenpotAPI, 'login_with_password'):
+        api = PenpotAPI(debug=False)
+        api.access_token = "test-token"
+        return api
+
+
+class TestCreateRectangle:
+    """Tests for create_rectangle method."""
+
+    def test_create_rectangle_basic(self, api_client):
+        """Test basic rectangle creation."""
+        rect = api_client.create_rectangle(100, 200, 300, 150)
+
+        assert rect['type'] == 'rect'
+        assert rect['name'] == 'Rectangle'
+        assert rect['x'] == 100
+        assert rect['y'] == 200
+        assert rect['width'] == 300
+        assert rect['height'] == 150
+        assert 'fills' in rect
+        assert len(rect['fills']) == 1
+        assert rect['fills'][0]['fillColor'] == '#000000'
+        assert rect['fills'][0]['fillOpacity'] == 1.0
+
+    def test_create_rectangle_with_custom_fill(self, api_client):
+        """Test rectangle with custom fill color."""
+        rect = api_client.create_rectangle(
+            100, 200, 300, 150,
+            fill_color="#FF0000",
+            fill_opacity=0.5
+        )
+
+        assert rect['fills'][0]['fillColor'] == '#FF0000'
+        assert rect['fills'][0]['fillOpacity'] == 0.5
+
+    def test_create_rectangle_with_stroke(self, api_client):
+        """Test rectangle with stroke."""
+        rect = api_client.create_rectangle(
+            100, 200, 300, 150,
+            stroke_color="#0000FF",
+            stroke_width=2.5
+        )
+
+        assert 'strokes' in rect
+        assert len(rect['strokes']) == 1
+        assert rect['strokes'][0]['strokeColor'] == '#0000FF'
+        assert rect['strokes'][0]['strokeWidth'] == 2.5
+
+    def test_create_rectangle_without_stroke(self, api_client):
+        """Test rectangle without stroke."""
+        rect = api_client.create_rectangle(100, 200, 300, 150)
+
+        assert 'strokes' not in rect
+
+    def test_create_rectangle_with_corner_radius(self, api_client):
+        """Test rectangle with corner radius."""
+        rect = api_client.create_rectangle(
+            100, 200, 300, 150,
+            rx=10,
+            ry=10
+        )
+
+        assert rect['rx'] == 10
+        assert rect['ry'] == 10
+
+    def test_create_rectangle_without_corner_radius(self, api_client):
+        """Test rectangle without corner radius."""
+        rect = api_client.create_rectangle(100, 200, 300, 150)
+
+        assert 'rx' not in rect
+        assert 'ry' not in rect
+
+    def test_create_rectangle_with_custom_name(self, api_client):
+        """Test rectangle with custom name."""
+        rect = api_client.create_rectangle(
+            100, 200, 300, 150,
+            name="My Custom Rectangle"
+        )
+
+        assert rect['name'] == "My Custom Rectangle"
+
+    def test_create_rectangle_with_kwargs(self, api_client):
+        """Test rectangle with additional properties via kwargs."""
+        rect = api_client.create_rectangle(
+            100, 200, 300, 150,
+            custom_property="custom_value",
+            another_prop=42
+        )
+
+        assert rect['custom_property'] == "custom_value"
+        assert rect['another_prop'] == 42
+
+
+class TestCreateCircle:
+    """Tests for create_circle method."""
+
+    def test_create_circle_basic(self, api_client):
+        """Test basic circle creation."""
+        circle = api_client.create_circle(150, 150, 50)
+
+        assert circle['type'] == 'circle'
+        assert circle['name'] == 'Circle'
+        assert circle['x'] == 100  # cx - radius
+        assert circle['y'] == 100  # cy - radius
+        assert circle['width'] == 100  # diameter
+        assert circle['height'] == 100  # diameter
+        assert 'fills' in circle
+        assert len(circle['fills']) == 1
+        assert circle['fills'][0]['fillColor'] == '#000000'
+        assert circle['fills'][0]['fillOpacity'] == 1.0
+
+    def test_create_circle_with_custom_fill(self, api_client):
+        """Test circle with custom fill color."""
+        circle = api_client.create_circle(
+            150, 150, 50,
+            fill_color="#00FF00",
+            fill_opacity=0.8
+        )
+
+        assert circle['fills'][0]['fillColor'] == '#00FF00'
+        assert circle['fills'][0]['fillOpacity'] == 0.8
+
+    def test_create_circle_with_stroke(self, api_client):
+        """Test circle with stroke."""
+        circle = api_client.create_circle(
+            150, 150, 50,
+            stroke_color="#FF0000",
+            stroke_width=3.0
+        )
+
+        assert 'strokes' in circle
+        assert len(circle['strokes']) == 1
+        assert circle['strokes'][0]['strokeColor'] == '#FF0000'
+        assert circle['strokes'][0]['strokeWidth'] == 3.0
+
+    def test_create_circle_without_stroke(self, api_client):
+        """Test circle without stroke."""
+        circle = api_client.create_circle(150, 150, 50)
+
+        assert 'strokes' not in circle
+
+    def test_create_circle_with_custom_name(self, api_client):
+        """Test circle with custom name."""
+        circle = api_client.create_circle(
+            150, 150, 50,
+            name="My Circle"
+        )
+
+        assert circle['name'] == "My Circle"
+
+    def test_create_circle_with_kwargs(self, api_client):
+        """Test circle with additional properties via kwargs."""
+        circle = api_client.create_circle(
+            150, 150, 50,
+            custom_property="custom_value"
+        )
+
+        assert circle['custom_property'] == "custom_value"
+
+    def test_create_ellipse_via_kwargs(self, api_client):
+        """Test creating an ellipse by overriding width/height via kwargs."""
+        circle = api_client.create_circle(
+            150, 150, 50,
+            width=200,  # Override to make ellipse
+            height=100
+        )
+
+        assert circle['width'] == 200
+        assert circle['height'] == 100
+
+
+class TestCreateText:
+    """Tests for create_text method."""
+
+    def test_create_text_basic(self, api_client):
+        """Test basic text creation."""
+        text = api_client.create_text(10, 20, "Hello World")
+
+        assert text['type'] == 'text'
+        assert text['name'] == 'Text'
+        assert text['x'] == 10
+        assert text['y'] == 20
+        assert text['content'] == 'Hello World'
+        assert 'fills' in text
+        assert text['fills'][0]['fillColor'] == '#000000'
+        assert text['fills'][0]['fillOpacity'] == 1.0
+        assert text['fontSize'] == 16
+        assert text['fontFamily'] == 'Work Sans'
+        assert text['fontWeight'] == 'normal'
+        assert text['textAlign'] == 'left'
+
+    def test_create_text_with_custom_font(self, api_client):
+        """Test text with custom font properties."""
+        text = api_client.create_text(
+            10, 20, "Hello World",
+            font_size=24,
+            font_family="Arial",
+            font_weight="bold"
+        )
+
+        assert text['fontSize'] == 24
+        assert text['fontFamily'] == "Arial"
+        assert text['fontWeight'] == "bold"
+
+    def test_create_text_with_custom_color(self, api_client):
+        """Test text with custom color."""
+        text = api_client.create_text(
+            10, 20, "Hello World",
+            fill_color="#FF0000"
+        )
+
+        assert text['fills'][0]['fillColor'] == '#FF0000'
+
+    def test_create_text_with_alignment(self, api_client):
+        """Test text with custom alignment."""
+        text = api_client.create_text(
+            10, 20, "Hello World",
+            text_align="center"
+        )
+
+        assert text['textAlign'] == "center"
+
+    def test_create_text_with_custom_name(self, api_client):
+        """Test text with custom name."""
+        text = api_client.create_text(
+            10, 20, "Hello World",
+            name="My Text"
+        )
+
+        assert text['name'] == "My Text"
+
+    def test_create_text_with_kwargs(self, api_client):
+        """Test text with additional properties via kwargs."""
+        text = api_client.create_text(
+            10, 20, "Hello World",
+            custom_property="custom_value"
+        )
+
+        assert text['custom_property'] == "custom_value"
+
+
+class TestCreateFrame:
+    """Tests for create_frame method."""
+
+    def test_create_frame_basic(self, api_client):
+        """Test basic frame creation."""
+        frame = api_client.create_frame(0, 0, 375, 812)
+
+        assert frame['type'] == 'frame'
+        assert frame['name'] == 'Frame'
+        assert frame['x'] == 0
+        assert frame['y'] == 0
+        assert frame['width'] == 375
+        assert frame['height'] == 812
+        assert 'fills' not in frame  # No background by default
+
+    def test_create_frame_with_background(self, api_client):
+        """Test frame with background color."""
+        frame = api_client.create_frame(
+            0, 0, 375, 812,
+            background_color="#FFFFFF"
+        )
+
+        assert 'fills' in frame
+        assert len(frame['fills']) == 1
+        assert frame['fills'][0]['fillColor'] == '#FFFFFF'
+        assert frame['fills'][0]['fillOpacity'] == 1.0
+
+    def test_create_frame_with_custom_name(self, api_client):
+        """Test frame with custom name."""
+        frame = api_client.create_frame(
+            0, 0, 375, 812,
+            name="iPhone"
+        )
+
+        assert frame['name'] == "iPhone"
+
+    def test_create_frame_with_kwargs(self, api_client):
+        """Test frame with additional properties via kwargs."""
+        frame = api_client.create_frame(
+            0, 0, 375, 812,
+            custom_property="custom_value"
+        )
+
+        assert frame['custom_property'] == "custom_value"
+
+
+class TestCreateGroup:
+    """Tests for create_group method."""
+
+    def test_create_group_basic(self, api_client):
+        """Test basic group creation."""
+        group = api_client.create_group()
+
+        assert group['type'] == 'group'
+        assert group['name'] == 'Group'
+
+    def test_create_group_with_custom_name(self, api_client):
+        """Test group with custom name."""
+        group = api_client.create_group(name="My Group")
+
+        assert group['name'] == "My Group"
+
+    def test_create_group_with_kwargs(self, api_client):
+        """Test group with additional properties via kwargs."""
+        group = api_client.create_group(
+            name="My Group",
+            custom_property="custom_value"
+        )
+
+        assert group['custom_property'] == "custom_value"
+
+
+class TestShapeHelperIntegration:
+    """Integration tests for shape helpers with change builders."""
+
+    def test_rectangle_with_add_obj_change(self, api_client):
+        """Test creating a rectangle and using it with add-obj change."""
+        rect = api_client.create_rectangle(100, 200, 300, 150, fill_color="#FF0000")
+        change = api_client.create_add_obj_change("rect-id", "page-id", rect)
+
+        assert change['type'] == 'add-obj'
+        assert change['id'] == 'rect-id'
+        assert change['pageId'] == 'page-id'
+        assert change['obj']['type'] == 'rect'
+        assert change['obj']['fills'][0]['fillColor'] == '#FF0000'
+
+    def test_circle_with_add_obj_change(self, api_client):
+        """Test creating a circle and using it with add-obj change."""
+        circle = api_client.create_circle(150, 150, 50, fill_color="#00FF00")
+        change = api_client.create_add_obj_change("circle-id", "page-id", circle)
+
+        assert change['type'] == 'add-obj'
+        assert change['id'] == 'circle-id'
+        assert change['obj']['type'] == 'circle'
+        assert change['obj']['width'] == 100
+
+    def test_text_with_add_obj_change(self, api_client):
+        """Test creating text and using it with add-obj change."""
+        text = api_client.create_text(10, 20, "Hello World", font_size=24)
+        change = api_client.create_add_obj_change("text-id", "page-id", text)
+
+        assert change['type'] == 'add-obj'
+        assert change['obj']['type'] == 'text'
+        assert change['obj']['content'] == 'Hello World'
+        assert change['obj']['fontSize'] == 24
+
+    def test_frame_with_add_obj_change(self, api_client):
+        """Test creating a frame and using it with add-obj change."""
+        frame = api_client.create_frame(0, 0, 375, 812, name="iPhone", background_color="#FFFFFF")
+        change = api_client.create_add_obj_change("frame-id", "page-id", frame)
+
+        assert change['type'] == 'add-obj'
+        assert change['obj']['type'] == 'frame'
+        assert change['obj']['name'] == 'iPhone'
+        assert change['obj']['width'] == 375
+
+    def test_multiple_shapes_workflow(self, api_client):
+        """Test creating multiple shapes in a single workflow."""
+        # Create multiple shapes
+        rect = api_client.create_rectangle(100, 100, 200, 150, fill_color="#FF0000")
+        circle = api_client.create_circle(300, 200, 50, fill_color="#00FF00")
+        text = api_client.create_text(100, 300, "Label", font_size=18)
+
+        # Create changes for all shapes
+        changes = [
+            api_client.create_add_obj_change("rect-1", "page-1", rect),
+            api_client.create_add_obj_change("circle-1", "page-1", circle),
+            api_client.create_add_obj_change("text-1", "page-1", text)
+        ]
+
+        assert len(changes) == 3
+        assert changes[0]['obj']['type'] == 'rect'
+        assert changes[1]['obj']['type'] == 'circle'
+        assert changes[2]['obj']['type'] == 'text'

--- a/tests/test_update_file.py
+++ b/tests/test_update_file.py
@@ -1,0 +1,508 @@
+"""Tests for update_file and change builder methods."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from penpot_mcp.api.penpot_api import PenpotAPI, RevisionConflictError
+
+
+@pytest.fixture
+def api_client():
+    """Create a PenpotAPI client for testing."""
+    with patch.object(PenpotAPI, 'login_with_password'):
+        api = PenpotAPI(debug=True)
+        api.access_token = "test-token"
+        return api
+
+
+class TestRevisionConflictError:
+    """Tests for RevisionConflictError exception."""
+
+    def test_revision_conflict_error_inheritance(self):
+        """Test that RevisionConflictError inherits from PenpotAPIError."""
+        from penpot_mcp.api.penpot_api import PenpotAPIError
+        error = RevisionConflictError("test")
+        assert isinstance(error, PenpotAPIError)
+
+    def test_revision_conflict_error_message(self):
+        """Test error message is preserved."""
+        error = RevisionConflictError("Revision mismatch")
+        assert str(error) == "Revision mismatch"
+
+
+class TestConvertChangesToTransit:
+    """Tests for _convert_changes_to_transit method."""
+
+    def test_convert_simple_change(self, api_client):
+        """Test conversion of a simple change operation."""
+        changes = [{'type': 'add-obj', 'id': 'obj-123', 'pageId': 'page-456'}]
+        transit = api_client._convert_changes_to_transit(changes)
+        
+        assert len(transit) == 1
+        assert transit[0]['~:type'] == '~:add-obj'
+        assert transit[0]['~:id'] == '~uobj-123'
+        assert transit[0]['~:pageId'] == '~upage-456'
+
+    def test_convert_nested_object(self, api_client):
+        """Test conversion with nested object."""
+        changes = [{
+            'type': 'add-obj',
+            'id': 'obj-123',
+            'pageId': 'page-456',
+            'obj': {
+                'type': 'rect',
+                'x': 0,
+                'y': 0
+            }
+        }]
+        transit = api_client._convert_changes_to_transit(changes)
+        
+        assert transit[0]['~:obj']['~:type'] == '~:rect'
+        assert transit[0]['~:obj']['~:x'] == 0
+        assert transit[0]['~:obj']['~:y'] == 0
+
+    def test_convert_with_operations_list(self, api_client):
+        """Test conversion with operations list."""
+        changes = [{
+            'type': 'mod-obj',
+            'id': 'obj-123',
+            'operations': [
+                {'type': 'set', 'attr': 'x', 'val': 100}
+            ]
+        }]
+        transit = api_client._convert_changes_to_transit(changes)
+        
+        assert transit[0]['~:operations'][0]['~:type'] == '~:set'
+        assert transit[0]['~:operations'][0]['~:attr'] == '~:x'
+        assert transit[0]['~:operations'][0]['~:val'] == 100
+
+    def test_convert_multiple_changes(self, api_client):
+        """Test conversion of multiple changes."""
+        changes = [
+            {'type': 'add-obj', 'id': 'obj-1', 'pageId': 'page-1'},
+            {'type': 'del-obj', 'id': 'obj-2', 'pageId': 'page-1'}
+        ]
+        transit = api_client._convert_changes_to_transit(changes)
+        
+        assert len(transit) == 2
+        assert transit[0]['~:type'] == '~:add-obj'
+        assert transit[1]['~:type'] == '~:del-obj'
+
+    def test_convert_preserves_non_uuid_strings(self, api_client):
+        """Test that non-UUID strings are preserved."""
+        changes = [{
+            'type': 'add-obj',
+            'id': 'obj-123',
+            'pageId': 'page-456',
+            'obj': {
+                'name': 'My Object'
+            }
+        }]
+        transit = api_client._convert_changes_to_transit(changes)
+        
+        # Name should not get ~u prefix
+        assert transit[0]['~:obj']['~:name'] == 'My Object'
+
+    def test_convert_with_frame_id(self, api_client):
+        """Test conversion with frameId field."""
+        changes = [{
+            'type': 'add-obj',
+            'id': 'obj-123',
+            'pageId': 'page-456',
+            'frameId': 'frame-789'
+        }]
+        transit = api_client._convert_changes_to_transit(changes)
+        
+        assert transit[0]['~:frameId'] == '~uframe-789'
+
+    def test_convert_with_parent_id(self, api_client):
+        """Test conversion with parentId field."""
+        changes = [{
+            'type': 'add-obj',
+            'id': 'obj-123',
+            'pageId': 'page-456',
+            'obj': {
+                'parentId': 'parent-789'
+            }
+        }]
+        transit = api_client._convert_changes_to_transit(changes)
+        
+        assert transit[0]['~:obj']['~:parentId'] == '~uparent-789'
+
+    def test_convert_with_numeric_values(self, api_client):
+        """Test conversion preserves numeric values."""
+        changes = [{
+            'type': 'mod-obj',
+            'id': 'obj-123',
+            'operations': [
+                {'type': 'set', 'attr': 'x', 'val': 100},
+                {'type': 'set', 'attr': 'y', 'val': 200.5}
+            ]
+        }]
+        transit = api_client._convert_changes_to_transit(changes)
+        
+        assert transit[0]['~:operations'][0]['~:val'] == 100
+        assert transit[0]['~:operations'][1]['~:val'] == 200.5
+
+    def test_convert_with_boolean_values(self, api_client):
+        """Test conversion preserves boolean values."""
+        changes = [{
+            'type': 'add-obj',
+            'id': 'obj-123',
+            'pageId': 'page-456',
+            'obj': {
+                'visible': True,
+                'locked': False
+            }
+        }]
+        transit = api_client._convert_changes_to_transit(changes)
+        
+        assert transit[0]['~:obj']['~:visible'] is True
+        assert transit[0]['~:obj']['~:locked'] is False
+
+
+class TestUpdateFile:
+    """Tests for update_file method."""
+
+    def test_update_file_success(self, api_client):
+        """Test successful file update."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            changes = [{'type': 'add-obj', 'id': 'obj-1', 'pageId': 'page-1', 'obj': {}}]
+            result = api_client.update_file('file-123', 'session-123', 10, changes)
+            
+            assert result['revn'] == 11
+            assert result['id'] == 'file-123'
+
+    def test_update_file_revision_conflict(self, api_client):
+        """Test that 409 status raises RevisionConflictError."""
+        mock_response = MagicMock()
+        mock_response.status_code = 409
+        
+        http_error = requests.HTTPError()
+        http_error.response = mock_response
+        
+        with patch.object(api_client, '_make_authenticated_request', side_effect=http_error):
+            changes = [{'type': 'add-obj', 'id': 'obj-1', 'pageId': 'page-1', 'obj': {}}]
+            
+            with pytest.raises(RevisionConflictError) as exc_info:
+                api_client.update_file('file-123', 'session-123', 10, changes)
+            
+            assert "Revision conflict" in str(exc_info.value)
+            assert "Expected 10" in str(exc_info.value)
+
+    def test_update_file_calls_transit_conversion(self, api_client):
+        """Test that update_file calls _convert_changes_to_transit."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            with patch.object(api_client, '_convert_changes_to_transit', wraps=api_client._convert_changes_to_transit) as mock_convert:
+                changes = [{'type': 'add-obj', 'id': 'obj-1', 'pageId': 'page-1', 'obj': {}}]
+                api_client.update_file('file-123', 'session-123', 10, changes)
+                
+                # Verify conversion was called
+                mock_convert.assert_called_once_with(changes)
+
+    def test_update_file_sends_correct_payload(self, api_client):
+        """Test that update_file sends correct payload structure."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_request:
+            changes = [{'type': 'add-obj', 'id': 'obj-1', 'pageId': 'page-1', 'obj': {}}]
+            api_client.update_file('file-123', 'session-456', 10, changes)
+            
+            # Get the call arguments
+            call_args = mock_request.call_args
+            payload = call_args[1]['json']
+            
+            # Verify payload structure
+            assert payload['id'] == 'file-123'
+            assert payload['session-id'] == 'session-456'
+            assert payload['revn'] == 10
+            assert 'changes' in payload
+            assert len(payload['changes']) == 1
+
+    def test_update_file_uses_transit_format(self, api_client):
+        """Test that update_file uses Transit+JSON format."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response) as mock_request:
+            changes = [{'type': 'add-obj', 'id': 'obj-1', 'pageId': 'page-1', 'obj': {}}]
+            api_client.update_file('file-123', 'session-123', 10, changes)
+            
+            # Verify use_transit=True was passed
+            call_args = mock_request.call_args
+            assert call_args[1]['use_transit'] is True
+
+    def test_update_file_with_multiple_changes(self, api_client):
+        """Test update_file with multiple change operations."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            changes = [
+                {'type': 'add-obj', 'id': 'obj-1', 'pageId': 'page-1', 'obj': {}},
+                {'type': 'mod-obj', 'id': 'obj-2', 'operations': []},
+                {'type': 'del-obj', 'id': 'obj-3', 'pageId': 'page-1'}
+            ]
+            result = api_client.update_file('file-123', 'session-123', 10, changes)
+            
+            assert result['revn'] == 11
+
+    def test_update_file_debug_logging(self, api_client, capsys):
+        """Test that debug logging works in update_file."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            changes = [{'type': 'add-obj', 'id': 'obj-1', 'pageId': 'page-1', 'obj': {}}]
+            api_client.update_file('file-123', 'session-123', 10, changes)
+            
+            captured = capsys.readouterr()
+            assert "Updating file file-123" in captured.out
+            assert "Session: session-123, Revision: 10" in captured.out
+            assert "Changes: 1 operations" in captured.out
+            assert "Update successful. New revision: 11" in captured.out
+
+
+class TestCreateAddObjChange:
+    """Tests for create_add_obj_change method."""
+
+    def test_create_add_obj_change_basic(self, api_client):
+        """Test basic add-obj change creation."""
+        obj = {'type': 'rect', 'x': 0, 'y': 0}
+        change = api_client.create_add_obj_change("obj-1", "page-1", obj)
+        
+        assert change['type'] == 'add-obj'
+        assert change['id'] == 'obj-1'
+        assert change['pageId'] == 'page-1'
+        assert change['obj'] == obj
+
+    def test_create_add_obj_change_with_frame(self, api_client):
+        """Test add-obj change with frame_id."""
+        obj = {'type': 'rect', 'x': 0, 'y': 0}
+        change = api_client.create_add_obj_change("obj-1", "page-1", obj, frame_id="frame-1")
+        
+        assert change['type'] == 'add-obj'
+        assert change['frameId'] == 'frame-1'
+
+    def test_create_add_obj_change_without_frame(self, api_client):
+        """Test that frameId is not included when None."""
+        obj = {'type': 'rect'}
+        change = api_client.create_add_obj_change("obj-1", "page-1", obj)
+        
+        assert 'frameId' not in change
+
+    def test_create_add_obj_change_with_complex_obj(self, api_client):
+        """Test add-obj change with complex object definition."""
+        obj = {
+            'type': 'rect',
+            'x': 100,
+            'y': 200,
+            'width': 300,
+            'height': 400,
+            'fill': '#ff0000',
+            'stroke': '#000000'
+        }
+        change = api_client.create_add_obj_change("obj-1", "page-1", obj)
+        
+        assert change['obj'] == obj
+        assert change['obj']['x'] == 100
+        assert change['obj']['fill'] == '#ff0000'
+
+
+class TestCreateModObjChange:
+    """Tests for create_mod_obj_change method."""
+
+    def test_create_mod_obj_change_basic(self, api_client):
+        """Test basic mod-obj change creation."""
+        operations = [{'type': 'set', 'attr': 'x', 'val': 100}]
+        change = api_client.create_mod_obj_change("obj-1", operations)
+        
+        assert change['type'] == 'mod-obj'
+        assert change['id'] == 'obj-1'
+        assert change['operations'] == operations
+
+    def test_create_mod_obj_change_multiple_operations(self, api_client):
+        """Test mod-obj change with multiple operations."""
+        operations = [
+            {'type': 'set', 'attr': 'x', 'val': 100},
+            {'type': 'set', 'attr': 'y', 'val': 200}
+        ]
+        change = api_client.create_mod_obj_change("obj-1", operations)
+        
+        assert len(change['operations']) == 2
+        assert change['operations'][0]['attr'] == 'x'
+        assert change['operations'][1]['attr'] == 'y'
+
+    def test_create_mod_obj_change_empty_operations(self, api_client):
+        """Test mod-obj change with empty operations list."""
+        change = api_client.create_mod_obj_change("obj-1", [])
+        
+        assert change['operations'] == []
+
+
+class TestCreateSetOperation:
+    """Tests for create_set_operation method."""
+
+    def test_create_set_operation_numeric(self, api_client):
+        """Test set operation with numeric value."""
+        op = api_client.create_set_operation('x', 100)
+        
+        assert op['type'] == 'set'
+        assert op['attr'] == 'x'
+        assert op['val'] == 100
+
+    def test_create_set_operation_string(self, api_client):
+        """Test set operation with string value."""
+        op = api_client.create_set_operation('name', 'My Object')
+        
+        assert op['attr'] == 'name'
+        assert op['val'] == 'My Object'
+
+    def test_create_set_operation_boolean(self, api_client):
+        """Test set operation with boolean value."""
+        op = api_client.create_set_operation('visible', True)
+        
+        assert op['attr'] == 'visible'
+        assert op['val'] is True
+
+    def test_create_set_operation_dict(self, api_client):
+        """Test set operation with dictionary value."""
+        op = api_client.create_set_operation('style', {'color': 'red'})
+        
+        assert op['attr'] == 'style'
+        assert op['val'] == {'color': 'red'}
+
+
+class TestCreateDelObjChange:
+    """Tests for create_del_obj_change method."""
+
+    def test_create_del_obj_change_basic(self, api_client):
+        """Test basic del-obj change creation."""
+        change = api_client.create_del_obj_change("obj-1", "page-1")
+        
+        assert change['type'] == 'del-obj'
+        assert change['id'] == 'obj-1'
+        assert change['pageId'] == 'page-1'
+
+    def test_create_del_obj_change_structure(self, api_client):
+        """Test del-obj change has correct structure."""
+        change = api_client.create_del_obj_change("obj-123", "page-456")
+        
+        # Should only have these three keys
+        assert len(change) == 3
+        assert 'type' in change
+        assert 'id' in change
+        assert 'pageId' in change
+
+
+class TestChangeBuilderIntegration:
+    """Integration tests for change builders with update_file."""
+
+    def test_add_obj_workflow(self, api_client):
+        """Test complete workflow: create add-obj change and update file."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            # Create change using builder
+            obj = {'type': 'rect', 'x': 0, 'y': 0, 'width': 100, 'height': 100}
+            change = api_client.create_add_obj_change("obj-1", "page-1", obj)
+            
+            # Update file with change
+            result = api_client.update_file('file-123', 'session-123', 10, [change])
+            
+            assert result['revn'] == 11
+
+    def test_mod_obj_workflow(self, api_client):
+        """Test complete workflow: create mod-obj change and update file."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            # Create change using builders
+            operations = [
+                api_client.create_set_operation('x', 100),
+                api_client.create_set_operation('y', 200)
+            ]
+            change = api_client.create_mod_obj_change("obj-1", operations)
+            
+            # Update file with change
+            result = api_client.update_file('file-123', 'session-123', 10, [change])
+            
+            assert result['revn'] == 11
+
+    def test_del_obj_workflow(self, api_client):
+        """Test complete workflow: create del-obj change and update file."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            # Create change using builder
+            change = api_client.create_del_obj_change("obj-1", "page-1")
+            
+            # Update file with change
+            result = api_client.update_file('file-123', 'session-123', 10, [change])
+            
+            assert result['revn'] == 11
+
+    def test_multiple_changes_workflow(self, api_client):
+        """Test workflow with multiple different change types."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_response.status_code = 200
+        
+        with patch.object(api_client, '_make_authenticated_request', return_value=mock_response):
+            # Create multiple changes
+            changes = [
+                api_client.create_add_obj_change("obj-new", "page-1", {'type': 'rect'}),
+                api_client.create_mod_obj_change("obj-existing", [
+                    api_client.create_set_operation('x', 50)
+                ]),
+                api_client.create_del_obj_change("obj-old", "page-1")
+            ]
+            
+            # Update file with all changes
+            result = api_client.update_file('file-123', 'session-123', 10, changes)
+            
+            assert result['revn'] == 11
+
+    def test_with_editing_session_context(self, api_client):
+        """Test change builders with editing_session context manager."""
+        mock_file_response = MagicMock()
+        mock_file_response.json.return_value = {'id': 'file-123', 'revn': 10}
+        
+        mock_update_response = MagicMock()
+        mock_update_response.json.return_value = {'id': 'file-123', 'revn': 11}
+        mock_update_response.status_code = 200
+        
+        with patch.object(api_client, 'get_file', return_value={'id': 'file-123', 'revn': 10}):
+            with patch.object(api_client, '_make_authenticated_request', return_value=mock_update_response):
+                # Use editing_session context
+                with api_client.editing_session("file-123") as (session_id, revn):
+                    # Create changes
+                    changes = [
+                        api_client.create_add_obj_change("obj-1", "page-1", {'type': 'rect'})
+                    ]
+                    
+                    # Update file
+                    result = api_client.update_file("file-123", session_id, revn, changes)
+                    
+                    assert result['revn'] == 11


### PR DESCRIPTION
## Summary

This PR adds comprehensive tests for actual MCP tool implementations, addressing feedback from code reviews on PR #26 and PR #28.

### What changed

Created `tests/test_mcp_tool_implementation.py` with 16 new tests that verify MCP tools work correctly through FastMCP's `call_tool()` method:

**Comment Tools (7 tests):**
- `add_design_comment` - basic success, with frame_id, error handling
- `reply_to_comment` - success case
- `get_file_comments` - all threads, filtered by page_id
- `resolve_comment_thread` - success case

**Library Tools (9 tests):**
- `link_library` - success case
- `list_library_components` - success case
- `import_component` - basic success, with frame_id
- `sync_library` - success case
- `publish_as_library` - success case
- `unpublish_library` - success case
- `get_file_libraries` - success case
- Error handling for library tools

### How it works

Each test:
1. **Mocks API methods** - Sets up expected API responses
2. **Invokes MCP tool** - Calls the actual tool through FastMCP's `call_tool()` method
3. **Verifies response structure** - Checks success flag, data fields, counts
4. **Verifies API calls** - Ensures API method was called with correct parameters
5. **Tests error handling** - Confirms errors are properly caught and returned

### Technical implementation

- Created async helper `call_tool_async()` that uses `server.mcp.call_tool(tool_name, kwargs)`
- Created sync wrapper `call_tool()` using asyncio event loop for pytest compatibility
- Tests parse MCP TextContent responses and validate JSON structure

### Test results

✅ All 16 new tests pass  
✅ All 334 total tests pass  
✅ No regressions

### Relationship to previous PRs

- **PR #26** and **PR #28** had tests labeled "MCP tool tests" that actually tested API mocks
- **PR #29** renamed those to "API mock tests" for clarity
- **This PR** adds the actual MCP tool implementation tests that were missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)